### PR TITLE
[DAT-429] Bump cryptography to 41.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cffi==1.14.3
 chardet==5.0.0
 click==8.1.3
 coverage==5.5
-cryptography==3.4.7
+cryptography==41.0.1
 docutils==0.16
 et-xmlfile==1.0.1
 flake8==3.8.4
@@ -47,6 +47,7 @@ pyinstaller-hooks-contrib==2020.8
 pylint==2.7.2
 pymongo==3.11.2
 PyMySQL==0.10.1
+pyOpenSSL==23.2.0
 pyparsing==2.4.7
 PyPDF2==1.27.5
 pytest==6.2.2


### PR DESCRIPTION
- added dependency and bump of pyOpenSSL==23.2.0