### PR TITLE
[DAT-494] Bump openpyxl to 3.1.2

### DIFF
--- a/cmdb/interface/rest_api/exporter_routes/export_object_routes.py
+++ b/cmdb/interface/rest_api/exporter_routes/export_object_routes.py
@@ -56,6 +56,6 @@ def export_objects(params: CollectionParameters, request_user: UserModel):
     except ModuleNotFoundError as error:
         return abort(400, error)
     except CMDBError as error:
-        return abort(404, jsonify(message='Not Found', error=error))
+        return abort(404, jsonify(message='Not Found', error='Export objects CMDBError'))
 
     return exporter.export()

--- a/cmdb/interface/rest_api/exporter_routes/exporter_object_routes.py
+++ b/cmdb/interface/rest_api/exporter_routes/exporter_object_routes.py
@@ -56,6 +56,6 @@ def export_objects(params: CollectionParameters, request_user: UserModel):
     except ModuleNotFoundError as error:
         return abort(400, error)
     except CMDBError as error:
-        return abort(404, jsonify(message='Not Found', error=error))
+        return abort(404, jsonify(message='Not Found', error='Export objects CMDBError'))
 
     return exporter.export()

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,12 +26,12 @@ isort==5.12.0
 itsdangerous==2.1.2
 jdcal==1.4.1
 Jinja2==3.1.2
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.9.0
 ldap3==2.9.1
 MarkupSafe==2.1.3
 mccabe==0.6.1
-openpyxl==3.0.5
-packaging==20.4
+openpyxl==3.1.2
+packaging==23.1
 pika==0.12.0
 Pillow==9.5.0
 pluggy==0.13.1


### PR DESCRIPTION
Bumped:
- openpyxl to 3.1.2
- lazy-object-proxy to 1.9.0
- packaging to 23.1

- fixed minor issues