### PR TITLE
[DAT-497] Bump python-dateutil to 2.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pika==0.12.0
 Pillow==9.5.0
 pluggy==0.13.1
 py==1.10.0
-pyasn1==0.4.8
+pyasn1==0.5.0
 pycodestyle==2.6.0
 pycparser==2.20
 pycryptodome==3.10.1
@@ -54,8 +54,8 @@ pytest==6.2.2
 pytest-cov==2.11.1
 pytest-html==3.1.1
 pytest-metadata==1.11.0
-python-dateutil==2.8.1
-pytz==2020.1
+python-dateutil==2.8.2
+pytz==2023.3
 reportlab==3.5.55
 requests==2.31.0
 six==1.16.0


### PR DESCRIPTION
Bumped:
- python-dateutil to 2.8.2
- pyasn1 to 0.5.0
- pytz to 2023.3