### PR TITLE
[DAT-500] Bumped pytest-html to 3.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2023.5.7
 cffi==1.14.3
 chardet==5.1.0
 click==8.1.3
-coverage==5.5
+coverage==7.2.7
 cryptography==41.0.1
 docutils==0.16
 et-xmlfile==1.1.0
@@ -38,7 +38,7 @@ pluggy==0.13.1
 py==1.10.0
 pyasn1==0.5.0
 pycodestyle==2.6.0
-pycparser==2.20
+pycparser==2.21
 pycryptodome==3.10.1
 pyflakes==2.2.0
 Pygments==2.7.1
@@ -52,7 +52,7 @@ pyparsing==2.4.7
 PyPDF2==1.28.6
 pytest==6.2.2
 pytest-cov==2.11.1
-pytest-html==3.1.1
+pytest-html==3.2.0
 pytest-metadata==1.11.0
 python-dateutil==2.8.2
 pytz==2023.3


### PR DESCRIPTION
Bumped:
- coverage to 7.2.7
- pycparser to 2.21
- pytest-html to 3.2.0