### PR TITLE
[DAT-506] Bump pytest to 7.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,10 +50,10 @@ PyMySQL==1.1.0
 pyOpenSSL==23.2.0
 pyparsing==2.4.7
 PyPDF2==1.28.6
-pytest==6.2.2
+pytest==7.4.0
 pytest-cov==4.1.0
 pytest-html==3.2.0
-pytest-metadata==1.11.0
+pytest-metadata==3.0.0
 python-dateutil==2.8.2
 pytz==2023.3
 reportlab==3.5.55
@@ -68,7 +68,7 @@ sphinxcontrib-httpdomain==1.8.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-toml==0.10.1
+toml==0.10.2
 urllib3==1.26.5
 webencodings==0.5.1
 Werkzeug==2.3.6


### PR DESCRIPTION
Bumped:
- pytest to 7.4.0
- pytest-metadata to 3.0.0
- toml to 0.10.2