### PR TITLE
[DAT-512] Bump Flask-Cors to 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 alabaster==0.7.13
 altgraph==0.17.3
 astroid==2.5.1
-attrs==20.3.0
+attrs==23.1.0
 Authlib==0.15.3
-Babel==2.9.1
+Babel==2.12.1
 blinker==1.6.2
 Cerberus==1.3.4
 certifi==2023.5.7
@@ -16,7 +16,7 @@ docutils==0.16
 et-xmlfile==1.1.0
 flake8==3.8.4
 Flask==2.3.2
-Flask-Cors==3.0.9
+Flask-Cors==4.0.0
 gunicorn==20.0.4
 html5lib==1.1
 idna==3.4


### PR DESCRIPTION
Bumped:
- Flask-Cors to 4.0.0
- attrs to 23.1.0
- Babel to 2.12.1