### PR TITLE
[DAT-528] Bump flake8 to 6.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ coverage==7.2.7
 cryptography==41.0.1
 docutils==0.16
 et-xmlfile==1.1.0
-flake8==3.8.4
+flake8==6.0.0
 Flask==2.3.2
 Flask-Cors==4.0.0
 gunicorn==20.1.0
@@ -29,7 +29,7 @@ Jinja2==3.1.2
 lazy-object-proxy==1.9.0
 ldap3==2.9.1
 MarkupSafe==2.1.3
-mccabe==0.6.1
+mccabe==0.7.0
 openpyxl==3.1.2
 packaging==23.1
 pika==0.12.0
@@ -37,10 +37,10 @@ Pillow==10.0.0
 pluggy==1.2.0
 py==1.11.0
 pyasn1==0.5.0
-pycodestyle==2.6.0
+pycodestyle==2.10.0
 pycparser==2.21
 pycryptodome==3.18.0
-pyflakes==2.2.0
+pyflakes==3.0.1
 Pygments==2.15.1
 pyinstaller==5.13.0
 pyinstaller-hooks-contrib==2023.4


### PR DESCRIPTION
Bumped:
- flake8 to 6.0.0
- pycodestyle to 2.10.0
- pyflakes to 3.0.1
- mccabe to 0.7.0