### PR TITLE
[DAT-539] Create Root Location automatically

### DIFF
--- a/cmdb/__check__.py
+++ b/cmdb/__check__.py
@@ -14,24 +14,45 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+"""
+This module contains logics for database validation and setup
+"""
+
 import logging
 from enum import Enum
+
+from cmdb.framework.cmdb_location import CmdbLocation
 
 LOGGER = logging.getLogger(__name__)
 
 
 class CheckRoutine:
+    """
+    This class holds checks for the database check routines
+    """
+
     class CheckStatus(Enum):
+        """
+        Enumeration of the status options for checks
+        """
         NOT = 0
         RUNNING = 1
         HAS_UPDATES = 2
         FINISHED = 3
 
+
     def __init__(self, dbm):
-        self.status = CheckRoutine.CheckStatus.NOT
+        self.status: int = CheckRoutine.CheckStatus.NOT
         self.setup_database_manager = dbm
 
-    def get_check_status(self):
+
+    def get_check_status(self) -> int:
+        """
+        Returns the CheckStatus of the current CheckRoutine
+
+        Returns:
+            (int): Current CheckStatus
+        """
         return self.status
 
     def checker(self):
@@ -49,6 +70,12 @@ class CheckRoutine:
         return self.status
 
     def __is_database_empty(self) -> bool:
+        """
+        Checks if there are any collections in the initialised database
+
+        Returns:
+            (bool): Returns bool if there are any collection in the initialised database
+        """
         return not self.setup_database_manager.connector.database.list_collection_names()
 
     def __check_database_collection_valid(self) -> bool:
@@ -63,6 +90,23 @@ class CheckRoutine:
             # framework collections
             for collection in FRAMEWORK_CLASSES:
                 collection_test = detected_database.validate_collection(collection.COLLECTION, scandata=True)['valid']
+
+                # setup locations if valid test
+                if collection == CmdbLocation and collection_test:
+                    root_location: CmdbLocation = self.setup_database_manager.find_one(collection.COLLECTION, 1)
+
+                    if root_location:
+                        if self.setup_database_manager.validate_root_location(CmdbLocation.to_data(root_location)):
+                            LOGGER.info("CHECK ROUTINE: Root Location valid")
+                        else:
+                            LOGGER.info("CHECK ROUTINE: Root Location invalalid => Fixing the Issue!")
+                            self.setup_database_manager.set_root_location(collection.COLLECTION, create=False)
+
+                    else:
+                        LOGGER.info("CHECK ROUTINE: No Root Location => Creating a new Root Location!")
+                        self.setup_database_manager.set_root_location(collection.COLLECTION, create=True)
+                        
+
             # user management collections
             for collection in USER_MANAGEMENT_COLLECTION:
                 collection_test = detected_database.validate_collection(collection.COLLECTION, scandata=True)['valid']
@@ -80,10 +124,11 @@ class CheckRoutine:
 
     def has_updates(self) -> bool:
         """
-        check if updates are available
-        Returns: True else raise error
+        Check if updates are available
 
-            """
+        Returns:
+            (bool): True if updates are available else raises an error
+        """
         from cmdb.updater import UpdaterModule
         from cmdb.utils.system_reader import SystemSettingsReader, SectionError
 
@@ -102,8 +147,10 @@ class CheckRoutine:
                     f'Newest Update Version: {new_version}'
                 )
                 return False
+
         except SectionError as err:
             LOGGER.error(err.message)
             return False
-        return True
 
+        return True
+    

--- a/cmdb/framework/cmdb_location.py
+++ b/cmdb/framework/cmdb_location.py
@@ -81,7 +81,7 @@ class CmdbLocation(CmdbDAO):
     #                               DUNDER FUNCTIONS                               #
     # ---------------------------------------------------------------------------- #
 
-    def __init__(self, name, parent, object_id, type_id, type_label, type_icon="fas fa-cube", type_selectable=True, **kwargs):
+    def __init__(self, name, parent, object_id, type_id, type_label, type_icon="fas fa-cube", type_selectable=True, public_id = None, **kwargs):
         """
         Initialisation of location
 
@@ -93,7 +93,9 @@ class CmdbLocation(CmdbDAO):
             type_label (str): label of type for which this location is set
             type_icon (str): icon of type for which this location is set, default is 'fas fa-cube'
             type_selectable (bool): sets if this type is selectable as a parent for other locations, default is yes
+            public_id (int): public_id of the location
         """
+        self.public_id: int = public_id
         self.name: str = name
         self.parent: int = parent
         self.object_id: int = object_id
@@ -155,9 +157,19 @@ class CmdbLocation(CmdbDAO):
     @classmethod
     def to_data(cls, instance: "CmdbLocation") -> dict:
         """
-        Not used
+        Dict representation of a CmdbLocation
         """
-        return []
+        return {
+            'public_id': instance['public_id'],
+            'name': instance['name'],
+            'parent': instance['parent'],
+            'object_id': instance['object_id'],
+            'type_id': instance['type_id'],
+            'type_label': instance['type_label'],
+            'type_icon': instance['type_icon'],
+            'type_selectable': instance['type_selectable'],
+        }
+
 
     @classmethod
     def to_dict(cls, instance: "CmdbLocation") -> dict:


### PR DESCRIPTION
Features:
* Root location automatically created or fixed on startup
* Create counter for framework.locations if none is existent (before creating root location)