### PR TITLE
DAT-668 tracking of global section templates

### DIFF
--- a/app/src/app/framework/models/cmdb-type.ts
+++ b/app/src/app/framework/models/cmdb-type.ts
@@ -15,84 +15,83 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-
 import { CmdbDao } from './cmdb-dao';
 import { AccessControlList } from '../../acl/acl.types';
-
-export interface CmdbTypeListEntry {
-  name: string;
-  label: string;
-  public_id: number;
-  render_meta: CmdbTypeMeta;
-}
-
-export class CmdbTypeList extends Array<CmdbTypeListEntry> {
-}
+/* ------------------------------------------------------------------------------------------------------------------ */
 
 export interface CmdbTypeSection {
-  type: string;
-  name: string;
-  label: string;
-  fields?: Array<any>;
-  reference?: {
-    type_id: number;
-    section_name: string;
-    selected_fields?: Array<string>;
-  };
+    type: string;
+    name: string;
+    label: string;
+    fields?: Array<any>;
+    reference?: {
+        type_id: number;
+        section_name: string;
+        selected_fields?: Array<string>;
+    };
 }
+
 
 export interface CmdbTypeExternalLink {
-  name: string;
-  href: string;
-  label: string;
-  icon: string;
-  fields: Array<any>;
+    name: string;
+    href: string;
+    label: string;
+    icon: string;
+    fields: Array<any>;
 }
+
 
 export interface CmdbTypeMeta {
-  icon: string;
-  sections: Array<CmdbTypeSection>;
-  externals: Array<CmdbTypeExternalLink>;
-  summary: CmdbTypeSummary;
+    icon: string;
+    sections: Array<CmdbTypeSection>;
+    externals: Array<CmdbTypeExternalLink>;
+    summary: CmdbTypeSummary;
 }
+
 
 export interface CmdbTypeSummary {
-  fields: Array<string>;
+    fields: Array<string>;
 }
 
+
 export class CmdbType implements CmdbDao {
+    public readonly public_id: number;
+    public name: string;
+    public label?: string;
+    public description?: string;
+    public active: boolean;
+    public selectable_as_parent: boolean;
+    public global_template_ids?: Array<string> = [];
+    public author_id: number;
+    public version: string;
+    public creation_time: any;
+    public editor_id: number;
+    public last_edit_time: any;
+    public render_meta: CmdbTypeMeta;
+    public fields: Array<any> = [];
+    public acl?: AccessControlList;
 
-  public readonly public_id: number;
-  public name: string;
-  public label?: string;
-  public description?: string;
-  public active: boolean;
-  public selectable_as_parent: boolean;
-  public author_id: number;
-  public version: string;
-  public creation_time: any;
-  public editor_id: number;
-  public last_edit_time: any;
-  public render_meta: CmdbTypeMeta;
-  public fields: Array<any> = [];
-  public acl?: AccessControlList;
 
-  public has_references(): boolean {
-    for (const field of this.fields) {
-      if (field.type === 'ref') {
-        return true;
-      }
+    public has_references(): boolean {
+        for (const field of this.fields) {
+            if (field.type === 'ref') {
+                return true;
+            }
+        }
+
+        return false;
     }
-    return false;
-  }
 
-  public get_reference_fields() {
-    const refFields = [];
-    for (const field of this.fields) {
-      if (field.type === 'ref') {
-        refFields.push(field);
-      }
+
+    public get_reference_fields() {
+        const refFields = [];
+
+        for (const field of this.fields) {
+            if (field.type === 'ref') {
+                refFields.push(field);
+            }
+        }
+
+        return refFields;
     }
-    return refFields;
-  }
 }

--- a/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.html
+++ b/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.html
@@ -1,11 +1,23 @@
 <div class="modal-header bg-primary text-white">
     <h4 class="modal-title">Section Template ID: {{sectionTemplate.public_id}}</h4>
     <button type="button" class="close" (click)="activeModal.close(0)"><span>&times;</span></button>
-  </div>
-  <div class="modal-body">
+</div>
+
+<div class="modal-body">
+    <div id="delete-message">
         Do you want to <b>delete</b> the section template <b>"{{sectionTemplate.label}}"</b>?
-  </div>
-  <div class="modal-footer">
+    </div>
+    <ng-container *ngIf="sectionTemplate.is_global">
+        <br>
+        <div class="warning-text">
+            This will delete this section and its fields from all types and corresponding objects.
+            <br>
+            This action can't be undone!
+        </div>
+    </ng-container>
+</div>
+
+<div class="modal-footer">
     <button type="button" class="btn btn-outline-dark" (click)="activeModal.close(0)">Close</button>
     <button type="submit" class="btn btn-danger" (click)="activeModal.close(sectionTemplate.public_id)">Delete</button>
 </div>

--- a/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.scss
+++ b/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.scss
@@ -1,0 +1,8 @@
+.warning-text{
+    color: red;
+    text-align: center;
+}
+
+#delete-message{
+    text-align: center;
+}

--- a/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.html
+++ b/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.html
@@ -81,7 +81,11 @@
                 </div>
                 <div class="collapse show" id="{{initialSection.name}}">
                     <div class="card-body">
-                        <cmdb-section-field-edit [data]="initialSection" [mode]="sectionTemplateID > 0 ? MODES.Global : MODES.Create" #sectionComponent></cmdb-section-field-edit>
+                        <cmdb-section-field-edit
+                            [data]="initialSection"
+                            [mode]="sectionTemplateID > 0 ? MODES.Global : MODES.Edit"
+                            #sectionComponent
+                        ></cmdb-section-field-edit>
                         <form [formGroup]="formGroup">
                             <div class="form-group is-global" *ngIf="sectionTemplateID <= 0">
                                 <mat-checkbox formControlName="isGlobal">

--- a/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.ts
+++ b/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.ts
@@ -17,8 +17,14 @@
 */
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { DndDropEvent } from 'ngx-drag-drop';
+import { Router } from '@angular/router';
+
 import { Observable } from 'rxjs';
+import { DndDropEvent } from 'ngx-drag-drop';
+
+import { ValidationService } from 'src/app/framework/type/services/validation.service';
+import { SectionTemplateService } from '../../services/section-template.service';
+import { ToastService } from 'src/app/layout/toast/toast.service';
 
 import { CmdbMode } from 'src/app/framework/modes.enum';
 import { CheckboxControl } from 'src/app/framework/type/builder/controls/choice/checkbox.control';
@@ -31,11 +37,7 @@ import { ReferenceControl } from 'src/app/framework/type/builder/controls/specia
 import { PasswordControl } from 'src/app/framework/type/builder/controls/text/password.control';
 import { TextControl } from 'src/app/framework/type/builder/controls/text/text.control';
 import { TextAreaControl } from 'src/app/framework/type/builder/controls/text/textarea.control';
-import { ValidationService } from 'src/app/framework/type/services/validation.service';
-import { SectionTemplateService } from '../../services/section-template.service';
-import { ToastService } from 'src/app/layout/toast/toast.service';
 import { APIInsertSingleResponse, APIUpdateSingleResponse } from 'src/app/services/models/api-response';
-import { Router } from '@angular/router';
 import { RenderResult } from 'src/app/framework/models/cmdb-render';
 import { SectionFieldEditComponent } from 'src/app/framework/type/builder/configs/section/section-field-edit.component';
 /* ------------------------------------------------------------------------------------------------------------------ */
@@ -50,7 +52,8 @@ export class SectionTemplateBuilderComponent implements OnInit {
     @Input()
     public sectionTemplateID: number;
 
-    @ViewChild('sectionComponent') public sectionComponent: SectionFieldEditComponent;
+    @ViewChild('sectionComponent')
+    public sectionComponent: SectionFieldEditComponent;
 
     public initialSection: any = {
         'name': this.randomName(),
@@ -58,7 +61,6 @@ export class SectionTemplateBuilderComponent implements OnInit {
         'type': 'section',
         'fields': []
     };
-
 
     public MODES: typeof CmdbMode = CmdbMode;
     public types = [];
@@ -99,7 +101,6 @@ export class SectionTemplateBuilderComponent implements OnInit {
 
 
     ngOnInit(): void {
-
         //EDIT MODE
         if(this.sectionTemplateID > 0){
             this.getSectionTemplate(this.sectionTemplateID);
@@ -109,10 +110,18 @@ export class SectionTemplateBuilderComponent implements OnInit {
 
         this.formGroup.controls['isGlobal'].valueChanges.subscribe(isGlobal => {
             if(isGlobal){
-                this.sectionComponent.form.controls['name'].setValue(this.generateGlobalSectionTemplateName());
+                if(this.initialSection.name.includes('dg_gst')){
+                    this.sectionComponent.form.controls['name'].setValue(this.initialSection.name);
+                } else {
+                    this.sectionComponent.form.controls['name'].setValue(this.generateGlobalSectionTemplateName());
+                }
             } 
             else {
-                this.sectionComponent.form.controls['name'].setValue(this.randomName());
+                if(this.initialSection.name.includes('section_template')){
+                    this.sectionComponent.form.controls['name'].setValue(this.initialSection.name);
+                } else {
+                    this.sectionComponent.form.controls['name'].setValue(this.randomName());
+                }
             }
         });
     }
@@ -186,6 +195,7 @@ export class SectionTemplateBuilderComponent implements OnInit {
             this.formGroup.controls.isGlobal.setValue(this.initialSection.is_global);
           });
     }
+
 /* ------------------------------------------------- EVENT HANDLERS ------------------------------------------------- */
 
     /**

--- a/app/src/app/framework/type/builder/builder.component.ts
+++ b/app/src/app/framework/type/builder/builder.component.ts
@@ -15,7 +15,14 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy,
+         Component,
+         EventEmitter,
+         Input,
+         OnChanges,
+         OnDestroy,
+         Output,
+         SimpleChanges } from '@angular/core';
 
 import { ReplaySubject } from 'rxjs';
 
@@ -132,6 +139,7 @@ export class BuilderComponent implements OnChanges, OnDestroy {
     ngOnChanges(changes: SimpleChanges): void {
         if(this.globalSectionTemplates.length > 0 && this.globalSectionTemplateFields.length == 0){
             this.initGlobalFieldsList();
+            this.setSelectedGlobalTemplates();
         }
     }
 
@@ -172,7 +180,6 @@ export class BuilderComponent implements OnChanges, OnDestroy {
      */
     public onSectionDrop(event: DndDropEvent): void {
         let sectionData = event.data;
-
         //check if it is a section template
         if('is_global' in sectionData){
 
@@ -190,11 +197,11 @@ export class BuilderComponent implements OnChanges, OnDestroy {
                 }
 
                 this.globalSectionTemplates.splice(index, 1);
+                this.typeInstance.global_template_ids.push(sectionData.name);
             }
 
             sectionData = this.extractSectionData(event.data);
         }
-
 
         if (this.sections && (event.dropEffect === 'copy' || event.dropEffect === 'move')) {
 
@@ -252,11 +259,9 @@ export class BuilderComponent implements OnChanges, OnDestroy {
 
 
     public onFieldDrop(event: DndDropEvent, section: CmdbTypeSection) {
-        console.log("onFieldDrop() - is global:",this.isGlobalSection(section));
         if(this.isGlobalSection(section)){
             return;
         }
-
 
         const fieldData = event.data;
 
@@ -354,14 +359,6 @@ export class BuilderComponent implements OnChanges, OnDestroy {
         this.typeInstance.render_meta.sections = [...this.typeInstance.render_meta.sections];
     }
 
-
-    public replaceAt(array, index, value) {
-        const ret = array.slice(0);
-        ret[index] = value;
-
-        return ret;
-    }
-
 /* -------------------------------------------- SECTION TEMPLATE HANDLING ------------------------------------------- */
 
     public getDnDEffectAllowedForField(field: any){
@@ -408,6 +405,28 @@ export class BuilderComponent implements OnChanges, OnDestroy {
     }
 
 
+    public setSelectedGlobalTemplates(){
+        if(this.typeInstance.global_template_ids.length > 0){
+            // iterate global_template_ids
+            this.typeInstance.global_template_ids.forEach((globalTemplateName) => {
+                
+                let index: number = -1;
+
+                for(let templateIndex in this.globalSectionTemplates){
+                    let aTemplate = this.globalSectionTemplates[templateIndex];
+
+                    if(aTemplate.name == globalTemplateName){
+                        this.selectedGlobalSectionTemplates.push(aTemplate);
+                        index = Number(templateIndex);
+                    }
+                }
+
+                this.globalSectionTemplates.splice(index, 1);
+            })
+        }
+    }
+
+
     public isGlobalField(fieldName: string){
         return this.globalSectionTemplateFields.indexOf(fieldName) > -1;
     }
@@ -441,9 +460,12 @@ export class BuilderComponent implements OnChanges, OnDestroy {
         }
 
         if(isGlobalTemplate){
+            const nameIndex = this.typeInstance.global_template_ids.indexOf(sectionData.name, 0);
+            this.typeInstance.global_template_ids.splice(nameIndex,1);
             this.selectedGlobalSectionTemplates.splice(globalTemplateIndex, 1);
         }
     }
+
 
     /**
      * 

--- a/cmdb/framework/cmdb_render.py
+++ b/cmdb/framework/cmdb_render.py
@@ -29,8 +29,8 @@ from cmdb.security.acl.errors import AccessDeniedError
 from cmdb.security.acl.permission import AccessControlPermission
 from cmdb.utils.error import CMDBError
 from cmdb.framework.cmdb_object import CmdbObject
-from cmdb.framework.models.type import TypeModel, TypeExternalLink, TypeFieldSection, TypeReference, \
-    TypeReferenceSection
+from cmdb.framework.models.type import TypeModel
+from cmdb.framework.models.type_model import TypeReference, TypeExternalLink, TypeFieldSection, TypeReferenceSection
 from cmdb.user_management.user_manager import UserModel
 from cmdb.user_management.managers.user_manager import UserManager
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -544,7 +544,7 @@ class RenderList:
 
         return preparation_objects
 
-
+# TODO: transfer errors to seperate class
 class RenderError(CMDBError):
     """
     Error class raised when an error occurs during rendering.

--- a/cmdb/framework/cmdb_section_template_manager.py
+++ b/cmdb/framework/cmdb_section_template_manager.py
@@ -21,14 +21,25 @@ The implementation of the manager used is always realized using the respective s
 import logging
 from queue import Queue
 
+from cmdb.framework.managers.type_manager import TypeManager
+from cmdb.framework.cmdb_object_manager import CmdbObjectManager
+from cmdb.framework.managers.object_manager import ObjectManager
+
 from cmdb.framework.cmdb_base import CmdbManagerBase
 from cmdb.user_management import UserModel
 from cmdb.security.acl.permission import AccessControlPermission
 from cmdb.framework import CmdbSectionTemplate
 from cmdb.utils.error import CMDBError
 from cmdb.database.errors.database_errors import PublicIDAlreadyExists
-from cmdb.framework.cmdb_errors import ObjectInsertError, SectionTemplateManagerDeleteError, SectionTemplateManagerError, \
-    SectionTemplateManagerInsertError
+from cmdb.framework.cmdb_errors import ObjectInsertError, \
+                                       SectionTemplateManagerDeleteError, \
+                                       SectionTemplateManagerError, \
+                                       SectionTemplateManagerInsertError
+from cmdb.framework.results.list import ListResult
+from cmdb.framework import TypeModel
+from cmdb.framework.models.type_model import TypeFieldSection
+from cmdb.framework.cmdb_object import CmdbObject
+
 # -------------------------------------------------------------------------------------------------------------------- #
 
 LOGGER = logging.getLogger(__name__)
@@ -40,6 +51,9 @@ class CmdbSectionTemplateManager(CmdbManagerBase):
     """
     def __init__(self, database_manager=None, event_queue: Queue = None):
         self._event_queue = event_queue
+        self.type_manager = TypeManager(database_manager)
+        self.cmdb_object_manager = CmdbObjectManager(database_manager)
+        self.object_manager = ObjectManager(database_manager, event_queue)
         super().__init__(database_manager)
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -111,6 +125,64 @@ class CmdbSectionTemplateManager(CmdbManagerBase):
 
 
 # ------------------------------------------------- HELPER FUNCTIONS ------------------------------------------------- #
+
+    def cleanup_global_section_templates(self, template_name: str) -> None:
+        """
+        Removes the global section template from types, summaries and objects
+
+        Args:
+            template_name (str): The name of the global section template
+        """
+        type_filter: dict = {
+            "global_template_ids":template_name
+        }
+
+        found_types: ListResult = self.type_manager.find(type_filter)
+
+        a_type: TypeModel
+        for a_type in found_types.results:
+            #remove the template_name from the type
+            a_type.global_template_ids.remove(template_name)
+
+            #remove the section from render_meta.sections
+            type_template_section: TypeFieldSection = a_type.get_section(template_name)
+
+            a_type.render_meta.sections = [section for section in a_type.render_meta.sections
+                                           if section.name != type_template_section.name]
+
+            #remove the fields in render_meta.sections.fields from type.fields
+            template_section_field_names: list[str] = type_template_section.get_fields()
+
+            a_type.fields = [field for field in a_type.fields if field['name'] not in template_section_field_names]
+
+            #remove all fields from summary
+            a_type.render_meta.summary.fields = [field_name for field_name in a_type.render_meta.summary.fields
+                                                  if field_name not in template_section_field_names]
+
+            #remove the fields from all objects which used this global section template
+            self.cleanup_global_section_objects(a_type.public_id, template_section_field_names)
+
+            #Update the type changes for the type
+            self.type_manager.update(a_type.public_id, a_type)
+
+
+    def cleanup_global_section_objects(self, type_id: int, section_field_names: list[str]) -> None:
+        """
+        Retrives all objects with the given type_id and deletes all fields provided
+
+        Args:
+            type_id (int): ID of the type for which the objects should be cleaned
+            section_field_names (list[str]): List of all fields which should be deleted 
+        """
+        section_objects: list = self.cmdb_object_manager.get_objects_by_type(type_id)
+
+        # remove section fields and update the objects
+        an_object: CmdbObject
+        for an_object in section_objects:
+            an_object.fields = [field for field in an_object.fields if field['name'] not in section_field_names]
+
+            self.object_manager.update(an_object.public_id, an_object)
+
 
     def get_new_id(self, collection: str) -> int:
         """

--- a/cmdb/framework/models/type.py
+++ b/cmdb/framework/models/type.py
@@ -13,14 +13,18 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
-"""TODO: document"""
+"""
+Represents a type in DATAGERRY
+Extends: CmdbDAO
+"""
 import logging
 from typing import List
 from datetime import datetime, timezone
 from dateutil.parser import parse
 
+from cmdb.framework.models.type_model import TypeSummary, TypeExternalLink, TypeSection, TypeRenderMeta
 from cmdb.framework.cmdb_dao import CmdbDAO, RequiredInitKeyNotFoundError
-from cmdb.framework.cmdb_errors import ExternalFillError, FieldInitError, FieldNotFoundError, TypeReferenceLineFillError
+from cmdb.framework.cmdb_errors import FieldInitError, FieldNotFoundError
 from cmdb.framework.utils import Collection, Model
 from cmdb.security.acl.control import AccessControlList
 from cmdb.utils.error import CMDBError
@@ -28,380 +32,9 @@ from cmdb.utils.error import CMDBError
 
 LOGGER = logging.getLogger(__name__)
 
-
-class TypeSummary:
-    """TODO: document"""
-
-    __slots__ = 'fields'
-
-    def __init__(self, fields: list = None):
-        self.fields = fields or []
-
-    def has_fields(self):
-        """TODO: document"""
-        return len(self.fields) > 0
-
-
-    def set_fields(self, fields):
-        """TODO: document"""
-        self.fields = fields
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeSummary":
-        """TODO: document"""
-        return cls(fields=data.get('fields', []))
-
-    @classmethod
-    def to_json(cls, instance: "TypeSummary") -> dict:
-        """TODO: document"""
-        return {
-            'fields': instance.fields
-        }
-
-
-class TypeReference:
-    """TODO: document"""
-
-    __slots__ = 'type_id', 'object_id', 'type_label', 'summaries', 'line', 'prefix', 'icon'
-
-    def __init__(self, type_id: int, object_id: int, type_label: str, line: str = None,
-                 prefix: bool = False, icon=None, summaries: list = None):
-        self.type_id = type_id
-        self.object_id = object_id
-        self.type_label = type_label or ''
-        self.summaries = summaries or []
-        self.line = line
-        self.icon = icon
-        self.prefix = prefix
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeReference":
-        """TODO: document"""
-        return cls(
-            type_id=data.get('type_id'),
-            object_id=data.get('object_id'),
-            line=data.get('line'),
-            type_label=data.get('type_label', None),
-            summaries=data.get('summaries', None),
-            icon=data.get('icon', False),
-            prefix=data.get('prefix', None)
-        )
-
-
-    @classmethod
-    def to_json(cls, instance: "TypeReference") -> dict:
-        """TODO: document"""
-        return {
-            'type_id': instance.type_id,
-            'object_id': instance.object_id,
-            'line': instance.line,
-            'type_label': instance.type_label,
-            'summaries': instance.summaries,
-            'icon': instance.icon,
-            'prefix': instance.prefix
-        }
-
-
-    def has_prefix(self):
-        """
-        check if reference has a prefix
-        """
-        if self.prefix:
-            return True
-        return False
-
-
-    def has_icon(self):
-        """
-        check if reference has a icon
-        """
-        if self.icon:
-            return True
-        return False
-
-
-    def line_requires_fields(self):
-        """
-        the type of arguments passed to it and formats it according to the format codes defined in the string
-        checks if the line requires field informations.
-        Examples:
-            example {} -> True
-            example -> False
-        Returns:
-            bool
-        """
-        import re
-        if re.search('{.*?}', self.line):
-            return True
-        return False
-
-
-    def has_summaries(self):
-        """
-        check if type references has summaries definitions
-        """
-        return len(self.summaries) > 0
-
-
-    def fill_line(self, inputs):
-        """fills the line brackets with data"""
-        try:
-            self.line = self.line.format(*inputs)
-        except Exception as err:
-            raise TypeReferenceLineFillError(inputs, err) from err
-
-
-class TypeExternalLink:
-    """TODO: document"""
-
-    __slots__ = 'name', 'href', 'label', 'icon', 'fields'
-
-    def __init__(self, name: str, href: str, label: str = None, icon: str = None, fields: list = None):
-        self.name = name
-        self.href = href
-        self.label = label or self.name.title()
-        self.icon = icon
-        self.fields = fields or []
-
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeExternalLink":
-        """TODO: document"""
-        return cls(
-            name=data.get('name'),
-            href=data.get('href'),
-            label=data.get('label', None),
-            icon=data.get('icon', None),
-            fields=data.get('fields', None)
-        )
-
-
-    @classmethod
-    def to_json(cls, instance: "TypeExternalLink") -> dict:
-        """TODO: document"""
-        return {
-            'name': instance.name,
-            'href': instance.href,
-            'label': instance.label,
-            'icon': instance.icon,
-            'fields': instance.fields
-        }
-
-
-    def has_icon(self):
-        """
-        check if external link has a icon
-        """
-        if self.icon:
-            return True
-        return False
-
-
-    def link_requires_fields(self):
-        """
-        the type of arguments passed to it and formats it according to the format codes defined in the string
-        checks if the href link requires field informations.
-        Examples:
-            http://example.org/{}/dynamic/ -> True
-            http://example.org/static/ -> False
-        Returns:
-            bool
-        """
-        import re
-        if re.search('{.*?}', self.href):
-            return True
-        return False
-
-
-    def has_fields(self):
-        """
-        check if external link has field definitions
-        """
-        if len(self.fields) > 0:
-            return True
-        return False
-
-
-    def fill_href(self, inputs):
-        """fills the href brackets with data"""
-        try:
-            self.href = self.href.format(*inputs)
-        except Exception as err:
-            raise ExternalFillError(inputs, err) from err
-
-
-class TypeSection:
-    """TODO: document"""
-
-    __slots__ = 'type', 'name', 'label'
-
-    def __init__(self, type: str, name: str, label: str = None):
-        self.type = type
-        self.name = name
-        self.label = label or self.name.title()
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeSection":
-        """TODO: document"""
-        return cls(
-            type=data.get('type'),
-            name=data.get('name'),
-            label=data.get('label', None),
-        )
-
-    @classmethod
-    def to_json(cls, instance: "TypeSection") -> dict:
-        """TODO: document"""
-        return {
-            'type': instance.type,
-            'name': instance.name,
-            'label': instance.label
-        }
-
-
-class TypeFieldSection(TypeSection):
-    """TODO: document"""
-
-    __slots__ = 'fields'
-
-    def __init__(self, type: str, name: str, label: str = None, fields: list = None):
-        self.fields = fields or []
-        super().__init__(type=type, name=name, label=label)
-
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeFieldSection":
-        return cls(
-            type=data.get('type'),
-            name=data.get('name'),
-            label=data.get('label', None),
-            fields=data.get('fields', None)
-        )
-
-    @classmethod
-    def to_json(cls, instance: "TypeFieldSection") -> dict:
-        return {
-            'type': instance.type,
-            'name': instance.name,
-            'label': instance.label,
-            'fields': instance.fields
-        }
-
-
-class TypeReferenceSectionEntry:
-    """TODO: document"""
-
-    __slots__ = 'type_id', 'section_name', 'selected_fields'
-
-    def __init__(self, type_id: int, section_name: str, selected_fields: List[str] = None):
-        self.type_id: int = type_id
-        self.section_name: str = section_name
-        self.selected_fields: List[str] = selected_fields or []
-
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeReferenceSectionEntry":
-        """TODO: document"""
-        return cls(
-            type_id=data.get('type_id'),
-            section_name=data.get('section_name'),
-            selected_fields=data.get('selected_fields', None))
-
-
-    @classmethod
-    def to_json(cls, instance: "TypeReferenceSectionEntry") -> dict:
-        """TODO: document"""
-        return {
-            'type_id': instance.type_id,
-            'section_name': instance.section_name,
-            'selected_fields': instance.selected_fields
-        }
-
-
-class TypeReferenceSection(TypeSection):
-    """TODO: document"""
-
-    __slots__ = 'reference', 'fields'
-
-    def __init__(self, type: str, name: str, label: str = None, reference: TypeReferenceSectionEntry = None,
-                 fields: list = None):
-        self.reference: reference = reference or {}
-        self.fields = fields or []
-        super().__init__(type=type, name=name, label=label)
-
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeReferenceSection":
-        reference = data.get('reference', None)
-        if reference:
-            reference = TypeReferenceSectionEntry.from_data(reference)
-        return cls(
-            type=data.get('type'),
-            name=data.get('name'),
-            label=data.get('label', None),
-            reference=reference,
-            fields=data.get('fields', None)
-        )
-
-
-    @classmethod
-    def to_json(cls, instance: "TypeReferenceSection") -> dict:
-        return {
-            'type': instance.type,
-            'name': instance.name,
-            'label': instance.label,
-            'reference': TypeReferenceSectionEntry.to_json(instance.reference),
-            'fields': instance.fields,
-        }
-
-
-class TypeRenderMeta:
-    """Class of the type models `render_meta` field"""
-
-    __slots__ = 'icon', 'sections', 'externals', 'summary'
-
-    def __init__(self, icon: str = None, sections: List[TypeSection] = None,
-                 externals: List[TypeExternalLink] = None,
-                 summary: TypeSummary = None):
-        self.icon: str = icon
-        self.sections: List[TypeSection] = sections or []
-        self.externals: List[TypeExternalLink] = externals or []
-        self.summary: TypeSummary = summary or TypeSummary(fields=None)
-
-
-    @classmethod
-    def from_data(cls, data: dict) -> "TypeRenderMeta":
-        """TODO: document"""
-        sections: List[TypeSection] = []
-        for section in data.get('sections', []):
-            section_type = section.get('type', 'section')
-            if section_type == 'section':
-                sections.append(TypeFieldSection.from_data(section))
-            elif section_type == 'ref-section':
-                sections.append(TypeReferenceSection.from_data(section))
-            else:
-                sections.append(TypeFieldSection.from_data(section))
-
-        return cls(
-            icon=data.get('icon', None),
-            sections=sections,
-            externals=[TypeExternalLink.from_data(external) for external in
-                       data.get('externals', None) or data.get('external', [])],
-            summary=TypeSummary.from_data(data.get('summary', {}))
-        )
-
-
-    @classmethod
-    def to_json(cls, instance: "TypeRenderMeta") -> dict:
-        """TODO: document"""
-        return {
-            'icon': instance.icon,
-            'sections': [section.to_json(section) for section in instance.sections],
-            'externals': [TypeExternalLink.to_json(external) for external in instance.externals],
-            'summary': TypeSummary.to_json(instance.summary)
-        }
-
-
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                       TypeModel                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
 class TypeModel(CmdbDAO):
     """
     Model class of the framework type.
@@ -442,6 +75,13 @@ class TypeModel(CmdbDAO):
         'selectable_as_parent': {
                 'type': 'boolean',
                 'default': True
+        },
+        'global_template_ids':{
+            'type': 'list',
+            'required': False,
+            'schema': {
+                'type': 'string',
+            }
         },
         'active': {
             'type': 'boolean',
@@ -680,19 +320,18 @@ class TypeModel(CmdbDAO):
         {'keys': [('name', CmdbDAO.DAO_ASCENDING)], 'name': 'name', 'unique': True}
     ]
 
-    __slots__ = 'public_id', 'name', 'label', 'description', 'version', 'selectable_as_parent' , 'active', \
-                'author_id', 'creation_time', 'render_meta', 'fields', 'acl'
-
 
     def __init__(self, public_id: int, name: str, author_id: int, render_meta: TypeRenderMeta,
                  creation_time: datetime = None, last_edit_time: datetime = None, editor_id: int = None,
-                 active: bool = True,  selectable_as_parent: bool = True, fields: list = None, version: str = None,
+                 active: bool = True,  selectable_as_parent: bool = True,
+                 global_template_ids: list[int] = None, fields: list = None, version: str = None,
                  label: str = None, description: str = None, acl: AccessControlList = None):
         self.name: str = name
         self.label: str = label or self.name.title()
         self.description: str = description
         self.version: str = version or TypeModel.DEFAULT_VERSION
         self.selectable_as_parent: bool = selectable_as_parent
+        self.global_template_ids: list = global_template_ids or []
         self.active: bool = active
         self.author_id: int = author_id
         self.creation_time: datetime = creation_time or datetime.now(timezone.utc)
@@ -703,10 +342,18 @@ class TypeModel(CmdbDAO):
         self.acl: AccessControlList = acl
         super().__init__(public_id=public_id)
 
-
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
     @classmethod
     def from_data(cls, data: dict) -> "TypeModel":
-        """Create a instance of TypeModel from database values"""
+        """
+        Generates a TypeModel object from a dict
+
+        Args:
+            data (dict): Data with which the TypeModel should be instantiated
+
+        Returns:
+            TypeModel: TypeModel class with given data
+        """
         creation_time = data.get('creation_time', None)
         if creation_time and isinstance(creation_time, str):
             creation_time = parse(creation_time, fuzzy=True)
@@ -716,20 +363,21 @@ class TypeModel(CmdbDAO):
             last_edit_time = parse(last_edit_time, fuzzy=True)
 
         return cls(
-            public_id=data.get('public_id'),
-            name=data.get('name'),
-            selectable_as_parent=data.get('selectable_as_parent', True),
-            active=data.get('active', True),
-            author_id=data.get('author_id'),
-            creation_time=creation_time,
-            editor_id=data.get('editor_id', None),
-            last_edit_time=last_edit_time,
-            label=data.get('label', None),
-            version=data.get('version', None),
-            description=data.get('description', None),
-            render_meta=TypeRenderMeta.from_data(data.get('render_meta', {})),
-            fields=data.get('fields', None) or [],
-            acl=AccessControlList.from_data(data.get('acl', {}))
+            public_id = data.get('public_id'),
+            name = data.get('name'),
+            selectable_as_parent = data.get('selectable_as_parent', True),
+            global_template_ids = data.get('global_template_ids', []),
+            active = data.get('active', True),
+            author_id = data.get('author_id'),
+            creation_time = creation_time,
+            editor_id = data.get('editor_id', None),
+            last_edit_time = last_edit_time,
+            label = data.get('label', None),
+            version = data.get('version', None),
+            description = data.get('description', None),
+            render_meta = TypeRenderMeta.from_data(data.get('render_meta', {})),
+            fields = data.get('fields', None) or [],
+            acl = AccessControlList.from_data(data.get('acl', {}))
         )
 
 
@@ -740,6 +388,7 @@ class TypeModel(CmdbDAO):
             'public_id': instance.get_public_id(),
             'name': instance.name,
             'selectable_as_parent': instance.selectable_as_parent,
+            'global_template_ids': instance.global_template_ids,
             'active': instance.active,
             'author_id': instance.author_id,
             'creation_time': instance.creation_time,
@@ -753,6 +402,8 @@ class TypeModel(CmdbDAO):
             'acl': AccessControlList.to_json(instance.acl)
         }
 
+
+# ------------------------------------------------- GENERAL FUNCTIONS ------------------------------------------------ #
 
     def get_name(self) -> str:
         """Get the name of the type"""
@@ -773,16 +424,16 @@ class TypeModel(CmdbDAO):
 
     def has_externals(self) -> bool:
         """Check if type has external links"""
-        return True if len(self.get_externals()) > 0 else False
+        return len(self.get_externals()) > 0
 
 
     def get_external(self, name) -> TypeExternalLink:
-        """TODO: document"""
+        """Retrive an external link"""
         return next((external for external in self.get_externals() if external.name == name), None)
 
 
-    def has_summaries(self):
-        """TODO: document"""
+    def has_summaries(self) -> bool:
+        """Checks if there are any fields in the render_meta.summary object"""
         return self.render_meta.summary.has_fields()
 
 
@@ -796,7 +447,7 @@ class TypeModel(CmdbDAO):
         return next((x['prefix'] for x in nested_summaries if x['type_id'] == self.public_id), False)
 
 
-    def get_nested_summary_fields(self, nested_summaries):
+    def get_nested_summary_fields(self, nested_summaries) -> list[str]:
         """TODO: document"""
         _fields = next((x['fields'] for x in nested_summaries if x['type_id'] == self.public_id), [])
         complete_field_list = []
@@ -811,7 +462,7 @@ class TypeModel(CmdbDAO):
         return next((x['line'] for x in nested_summaries if x['type_id'] == self.public_id), None)
 
 
-    def get_summary(self):
+    def get_summary(self) -> TypeSummary:
         """TODO: document"""
         complete_field_list = []
         for field_name in self.render_meta.summary.fields:
@@ -824,36 +475,47 @@ class TypeModel(CmdbDAO):
         return self.render_meta.sections
 
 
-    def get_section(self, name):
-        """TODO: document"""
+    def get_section(self, name: str) -> TypeSection:
+        """
+        Retrieves a section with the given name
+
+        Args:
+            name (str): Name of the section
+
+        Returns:
+            TypeSection: The Typesection with the given name else None
+        """
         try:
             return next((section for section in self.get_sections() if section.name == name), None)
         except IndexError:
             return None
 
 
-    def get_icon(self):
-        """TODO: document"""
+    def get_icon(self) -> str:
+        """Retrieves the icon of the current TypeModel"""
         try:
             return self.render_meta.icon
         except IndexError:
             return None
 
 
-    def has_sections(self):
-        """TODO: document"""
-        if len(self.get_sections()) == 0:
-            return False
-        return True
+    def has_sections(self) -> bool:
+        """
+        Checks if the TypeModel has any sections
+
+        Returns:
+            (bool): True if at least one section is present else False
+        """
+        return self.get_sections() > 0
 
 
     def get_fields(self) -> list:
-        """TODO: document"""
+        """Retuns all fields of the TypeModel"""
         return self.fields
 
 
     def count_fields(self) -> int:
-        """TODO: document"""
+        """Returns the number of fields"""
         return len(self.fields)
 
 

--- a/cmdb/framework/models/type_model/__init__.py
+++ b/cmdb/framework/models/type_model/__init__.py
@@ -14,15 +14,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-This module contains all models used by DATAGERRY
+This module contains all classes regarding the Cmdb-Type 'Type'
 """
-from .type import TypeModel
-from .category import CategoryModel
-from .link import ObjectLinkModel
+from .type_summary import TypeSummary
+from .type_reference import TypeReference
+from .type_external_link import TypeExternalLink
+from .type_section import TypeSection
+from .type_field_section import TypeFieldSection
+from .type_reference_section_entry import TypeReferenceSectionEntry
+from .type_reference_section import TypeReferenceSection
+from.type_render_meta import TypeRenderMeta
 # -------------------------------------------------------------------------------------------------------------------- #
 
 __all__ = [
-    'CategoryModel',
-    'TypeModel',
-    'ObjectLinkModel'
+    'TypeSummary',
+    'TypeReference',
+    'TypeExternalLink',
+    'TypeSection',
+    'TypeFieldSection',
+    'TypeReferenceSectionEntry',
+    'TypeReferenceSection',
+    'TypeRenderMeta'
 ]

--- a/cmdb/framework/models/type_model/type_external_link.py
+++ b/cmdb/framework/models/type_model/type_external_link.py
@@ -1,0 +1,125 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+This class represents an external link
+"""
+import logging
+import re
+
+from cmdb.framework.cmdb_errors import ExternalFillError
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   TypeExternalLink                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeExternalLink:
+    """This class represents an external link"""
+
+    def __init__(self, name: str, href: str, label: str = None, icon: str = None, fields: list = None):
+        self.name = name
+        self.href = href
+        self.label = label or self.name.title()
+        self.icon = icon
+        self.fields = fields or []
+
+
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
+
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeExternalLink":
+        """
+        Generates a TypeExternalLink object from a dict
+
+        Args:
+            data (dict): Data with which the TypeExternalLink should be instantiated
+
+        Returns:
+            TypeExternalLink: TypeExternalLink class with given data
+        """
+        return cls(
+            name = data.get('name'),
+            href = data.get('href'),
+            label = data.get('label', None),
+            icon = data.get('icon', None),
+            fields = data.get('fields', None)
+        )
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeExternalLink") -> dict:
+        """
+        Returns a TypeExternalLink as JSON representation
+
+        Args:
+            instance (TypeExternalLink): TypeExternalLink which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeExternalLink
+        """
+        return {
+            'name': instance.name,
+            'href': instance.href,
+            'label': instance.label,
+            'icon': instance.icon,
+            'fields': instance.fields
+        }
+
+
+# ------------------------------------------------- GENERAL FUNCTIONS ------------------------------------------------ #
+
+    def has_icon(self) -> bool:
+        """
+        Checks if the TypeExternalLink has an icon
+
+        Returns:
+            (bool): True if icon is set else False
+        """
+        return bool(self.icon)
+
+
+    def link_requires_fields(self) -> bool:
+        """
+        the type of arguments passed to it and formats it according to the format codes defined in the string
+        checks if the href link requires field informations.
+        Examples:
+            http://example.org/{}/dynamic/ -> True
+            http://example.org/static/ -> False
+        Returns:
+            bool
+        """
+        if re.search('{.*?}', self.href):
+            return True
+        return False
+
+
+    def has_fields(self) -> bool:
+        """
+        Checks if the TypeExternalLink has any fields
+
+        Returns:
+            (bool): True if at least one field is set else False
+        """
+        return len(self.fields) > 0
+
+
+    def fill_href(self, inputs) -> None:
+        """Fills the href brackets with data"""
+        try:
+            self.href = self.href.format(*inputs)
+        except Exception as err:
+            raise ExternalFillError(inputs, err) from err

--- a/cmdb/framework/models/type_model/type_field_section.py
+++ b/cmdb/framework/models/type_model/type_field_section.py
@@ -1,0 +1,89 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+This class represents a type field section
+Extends: TypeSection
+"""
+import logging
+
+from cmdb.framework.models.type_model import TypeSection
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                   TypeFieldSection                                                   #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeFieldSection(TypeSection):
+    """
+    This class represents a type field section
+    Extends: TypeSection
+    """
+
+    def __init__(self, type: str, name: str, label: str = None, fields: list = None):
+        self.fields = fields or []
+        super().__init__(type=type, name=name, label=label)
+
+
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
+
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeFieldSection":
+        """
+        Generates a TypeFieldSection object from a dict
+
+        Args:
+            data (dict): Data with which the TypeFieldSection should be instantiated
+
+        Returns:
+            TypeFieldSection: TypeFieldSection class with given data
+        """
+        return cls(
+            type = data.get('type'),
+            name = data.get('name'),
+            label = data.get('label', None),
+            fields = data.get('fields', None)
+        )
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeFieldSection") -> dict:
+        """
+        Returns a TypeFieldSection as JSON representation
+
+        Args:
+            instance (TypeFieldSection): TypeFieldSection which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeFieldSection
+        """
+        return {
+            'type': instance.type,
+            'name': instance.name,
+            'label': instance.label,
+            'fields': instance.fields
+        }
+    
+# -------------------------------------------------- GENERAL METHODS ------------------------------------------------- #
+
+    def get_fields(self) -> list:
+        """
+        Retrieves all fields of the section
+
+        Returns:
+            list: All fields of the section
+        """
+        return self.fields

--- a/cmdb/framework/models/type_model/type_reference.py
+++ b/cmdb/framework/models/type_model/type_reference.py
@@ -1,0 +1,140 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+This class represents a type reference
+"""
+import logging
+import re
+
+from cmdb.framework.cmdb_errors import TypeReferenceLineFillError
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                     TypeReference                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeReference:
+    """Represents a type reference"""
+
+    def __init__(self, type_id: int, object_id: int, type_label: str, line: str = None,
+                 prefix: bool = False, icon=None, summaries: list = None):
+        self.type_id = type_id
+        self.object_id = object_id
+        self.type_label = type_label or ''
+        self.summaries = summaries or []
+        self.line = line
+        self.icon = icon
+        self.prefix = prefix
+
+# -------------------------------------------------- CLASS FUCNTIONS ------------------------------------------------- #
+
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeReference":
+        """
+        Generates a TypeReference object from a dict
+
+        Args:
+            data (dict): Data with which the TypeReference should be instantiated
+
+        Returns:
+            TypeReference: TypeReference class with given data
+        """
+        return cls(
+            type_id = data.get('type_id'),
+            object_id = data.get('object_id'),
+            line = data.get('line'),
+            type_label = data.get('type_label', None),
+            summaries = data.get('summaries', None),
+            icon = data.get('icon', False),
+            prefix = data.get('prefix', None)
+        )
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeReference") -> dict:
+        """
+        Returns a TypeReference as JSON representation
+
+        Args:
+            instance (TypeReference): TypeReference which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeReference
+        """
+        return {
+            'type_id': instance.type_id,
+            'object_id': instance.object_id,
+            'line': instance.line,
+            'type_label': instance.type_label,
+            'summaries': instance.summaries,
+            'icon': instance.icon,
+            'prefix': instance.prefix
+        }
+
+# ------------------------------------------------- GENERAL FUNCTIONS ------------------------------------------------ #
+
+    def has_prefix(self) -> bool:
+        """
+        Checks if the TypeReference has a prefix
+
+        Returns:
+            (bool): True if prefix is set else False
+        """
+        return bool(self.prefix)
+
+
+    def has_icon(self) -> bool:
+        """
+        Checks if the TypeReference has an icon
+
+        Returns:
+            (bool): True if icon is set else False
+        """
+        return bool(self.icon)
+
+
+    def line_requires_fields(self) -> bool:
+        """
+        The type of arguments passed to it and formats it according to the format codes defined in the string
+        checks if the line requires field informations.
+        Examples:
+            example {} -> True
+            example -> False
+        Returns:
+            bool
+        """
+        if re.search('{.*?}', self.line):
+            return True
+        return False
+
+
+    def has_summaries(self) -> bool:
+        """
+        Checks if the TypeReference has summaries
+
+        Returns:
+            (bool): True if at least one summary is set else False
+        """
+        return len(self.summaries) > 0
+
+
+    def fill_line(self, inputs) -> None:
+        """Fills the line brackets with data"""
+        try:
+            self.line = self.line.format(*inputs)
+        except Exception as err:
+            raise TypeReferenceLineFillError(inputs, err) from err

--- a/cmdb/framework/models/type_model/type_reference_section.py
+++ b/cmdb/framework/models/type_model/type_reference_section.py
@@ -1,0 +1,85 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+This class represents a type reference section
+Extends: TypeSection
+"""
+import logging
+
+from cmdb.framework.models.type_model import TypeSection, TypeReferenceSectionEntry
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                 TypeReferenceSection                                                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeReferenceSection(TypeSection):
+    """
+    This class represents a type reference section
+    Extends: TypeSection
+    """
+
+    def __init__(self, type: str, name: str, label: str = None, reference: TypeReferenceSectionEntry = None,
+                 fields: list = None):
+        self.reference: reference = reference or {}
+        self.fields = fields or []
+        super().__init__(type=type, name=name, label=label)
+
+
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeReferenceSection":
+        """
+        Generates a TypeReferenceSection object from a dict
+
+        Args:
+            data (dict): Data with which the TypeReferenceSection should be instantiated
+
+        Returns:
+            TypeReferenceSection: TypeReferenceSection class with given data
+        """
+        reference = data.get('reference', None)
+        if reference:
+            reference = TypeReferenceSectionEntry.from_data(reference)
+
+        return cls(
+            type = data.get('type'),
+            name = data.get('name'),
+            label = data.get('label', None),
+            reference = reference,
+            fields = data.get('fields', None)
+        )
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeReferenceSection") -> dict:
+        """
+        Returns a TypeReferenceSection as JSON representation
+
+        Args:
+            instance (TypeReferenceSection): TypeReferenceSection which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeReferenceSection
+        """
+        return {
+            'type': instance.type,
+            'name': instance.name,
+            'label': instance.label,
+            'reference': TypeReferenceSectionEntry.to_json(instance.reference),
+            'fields': instance.fields,
+        }

--- a/cmdb/framework/models/type_model/type_reference_section_entry.py
+++ b/cmdb/framework/models/type_model/type_reference_section_entry.py
@@ -1,0 +1,73 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+This class represents a type reference section entry
+"""
+import logging
+from typing import List
+
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                               TypeReferenceSectionEntry                                              #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeReferenceSectionEntry:
+    """This class represents a type reference section entry"""
+
+    def __init__(self, type_id: int, section_name: str, selected_fields: List[str] = None):
+        self.type_id: int = type_id
+        self.section_name: str = section_name
+        self.selected_fields: List[str] = selected_fields or []
+
+
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
+
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeReferenceSectionEntry":
+        """
+        Generates a TypeReferenceSectionEntry object from a dict
+
+        Args:
+            data (dict): Data with which the TypeReferenceSectionEntry should be instantiated
+
+        Returns:
+            TypeReferenceSectionEntry: TypeReferenceSectionEntry class with given data
+        """
+        return cls(
+            type_id = data.get('type_id'),
+            section_name = data.get('section_name'),
+            selected_fields = data.get('selected_fields', None)
+        )
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeReferenceSectionEntry") -> dict:
+        """
+        Returns a TypeReferenceSectionEntry as JSON representation
+
+        Args:
+            instance (TypeReferenceSectionEntry): TypeReferenceSectionEntry which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeReferenceSectionEntry
+        """
+        return {
+            'type_id': instance.type_id,
+            'section_name': instance.section_name,
+            'selected_fields': instance.selected_fields
+        }

--- a/cmdb/framework/models/type_model/type_render_meta.py
+++ b/cmdb/framework/models/type_model/type_render_meta.py
@@ -1,0 +1,94 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+This class represents type render meta
+"""
+import logging
+from typing import List
+
+from cmdb.framework.models.type_model import TypeSection, \
+                                             TypeExternalLink, \
+                                             TypeSummary, \
+                                             TypeFieldSection, \
+                                             TypeReferenceSection
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                    TypeRenderMeta                                                    #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeRenderMeta:
+    """Class of the type models `render_meta` field"""
+
+    def __init__(self, icon: str = None, sections: List[TypeSection] = None,
+                 externals: List[TypeExternalLink] = None,
+                 summary: TypeSummary = None):
+        self.icon: str = icon
+        self.sections: List[TypeSection] = sections or []
+        self.externals: List[TypeExternalLink] = externals or []
+        self.summary: TypeSummary = summary or TypeSummary(fields=None)
+
+
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
+
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeRenderMeta":
+        """
+        Generates a TypeRenderMeta object from a dict
+
+        Args:
+            data (dict): Data with which the TypeRenderMeta should be instantiated
+
+        Returns:
+            TypeRenderMeta: TypeRenderMeta class with given data
+        """
+        sections: List[TypeSection] = []
+        for section in data.get('sections', []):
+            section_type = section.get('type', 'section')
+            if section_type == 'section':
+                sections.append(TypeFieldSection.from_data(section))
+            elif section_type == 'ref-section':
+                sections.append(TypeReferenceSection.from_data(section))
+            else:
+                sections.append(TypeFieldSection.from_data(section))
+
+        return cls(
+            icon=data.get('icon', None),
+            sections=sections,
+            externals=[TypeExternalLink.from_data(external) for external in
+                       data.get('externals', None) or data.get('external', [])],
+            summary=TypeSummary.from_data(data.get('summary', {}))
+        )
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeRenderMeta") -> dict:
+        """
+        Returns a TypeRenderMeta as JSON representation
+
+        Args:
+            instance (TypeRenderMeta): TypeRenderMeta which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeRenderMeta
+        """
+        return {
+            'icon': instance.icon,
+            'sections': [section.to_json(section) for section in instance.sections],
+            'externals': [TypeExternalLink.to_json(external) for external in instance.externals],
+            'summary': TypeSummary.to_json(instance.summary)
+        }

--- a/cmdb/framework/models/type_model/type_section.py
+++ b/cmdb/framework/models/type_model/type_section.py
@@ -1,0 +1,71 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+This class represents a type section
+"""
+import logging
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                      TypeSection                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeSection:
+    """Type section class"""
+
+    def __init__(self, type: str, name: str, label: str = None):
+        self.type = type
+        self.name = name
+        self.label = label or self.name.title()
+
+
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
+
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeSection":
+        """
+        Generates a TypeSection object from a dict
+
+        Args:
+            data (dict): Data with which the TypeSection should be instantiated
+
+        Returns:
+            TypeSection: TypeSection class with given data
+        """
+        return cls(
+            type = data.get('type'),
+            name = data.get('name'),
+            label = data.get('label', None),
+        )
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeSection") -> dict:
+        """
+        Returns a TypeSection as JSON representation
+
+        Args:
+            instance (TypeSection): TypeSection which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeSection
+        """
+        return {
+            'type': instance.type,
+            'name': instance.name,
+            'label': instance.label
+        }

--- a/cmdb/framework/models/type_model/type_summary.py
+++ b/cmdb/framework/models/type_model/type_summary.py
@@ -1,0 +1,86 @@
+# DATAGERRY - OpenSource Enterprise CMDB
+# Copyright (C) 2023 becon GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+Class - Contains the summary fields of the CmdbType 'Type'
+"""
+import logging
+# -------------------------------------------------------------------------------------------------------------------- #
+
+LOGGER = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                      TypeSummary                                                     #
+# -------------------------------------------------------------------------------------------------------------------- #
+class TypeSummary:
+    """
+    Contains the summary fields of the CmdbType 'Type'
+    """
+    def __init__(self, fields: list[str] = None):
+        self.fields = fields or []
+
+
+# -------------------------------------------------- CLASS FUNCTIONS ------------------------------------------------- #
+
+    @classmethod
+    def from_data(cls, data: dict) -> "TypeSummary":
+        """
+        Generates a TypeSummary object from a dict
+
+        Args:
+            data (dict): Data with which the TypeSummary should be instantiated
+
+        Returns:
+            TypeSummary: TypeSummary class with given data
+        """
+        return cls(fields = data.get('fields', []))
+
+
+    @classmethod
+    def to_json(cls, instance: "TypeSummary") -> dict:
+        """
+        Returns a TypeSummary as JSON representation
+
+        Args:
+            instance (TypeSummary): TypeSummary which should be transformed
+
+        Returns:
+            dict: JSON representation of the given TypeSummary
+        """
+        return {
+            'fields': instance.fields
+        }
+
+
+# ------------------------------------------------- GENERAL FUNCTIONS ------------------------------------------------ #
+
+    def has_fields(self) -> bool:
+        """
+        Checks if the TypeSummary has any fields
+
+        Returns:
+            (bool): True if at least one field is set else False
+        """
+        return len(self.fields) > 0
+
+
+    def set_fields(self, fields: list[str]) -> None:
+        """
+        Sets the 'fields' attribute of the TypeSummary
+
+        Args:
+            fields (list[str]): List of field names which are used for the TypeSummary
+        """
+        self.fields = fields

--- a/cmdb/interface/rest_api/framework_routes/section_template_routes.py
+++ b/cmdb/interface/rest_api/framework_routes/section_template_routes.py
@@ -196,7 +196,10 @@ def update_section_template(params: dict, request_user: UserModel):
 def delete_section_template(public_id: int, request_user: UserModel):
     """TODO: document"""
     try:
-        current_section_template_instance = section_template_manager.get_section_template(public_id)
+        template_instance: CmdbSectionTemplate = section_template_manager.get_section_template(public_id)
+
+        if template_instance.is_global:
+             section_template_manager.cleanup_global_section_templates(template_instance.name)
 
         ack = section_template_manager.delete_section_template(public_id=public_id,
                                                user=request_user,

--- a/tests/functional/framework/test_functional_objects.py
+++ b/tests/functional/framework/test_functional_objects.py
@@ -13,21 +13,23 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
-
+"""TODO: document"""
 from json import dumps
 from datetime import datetime, timezone
 from http import HTTPStatus
 
 from pytest import fixture
 
+from cmdb.framework.models.type_model import TypeSummary
 from cmdb.framework import TypeModel, CmdbObject
-from cmdb.framework.models.type import TypeRenderMeta, TypeFieldSection, TypeSummary
+from cmdb.framework.models.type_model import TypeFieldSection, TypeRenderMeta
 from cmdb.security.acl.control import AccessControlList
 from cmdb.security.acl.sections import GroupACL
-
+# -------------------------------------------------------------------------------------------------------------------- #
 
 @fixture(scope='module')
 def example_type():
+    """TODO: document"""
     return TypeModel(
         public_id=1, name='test', label='Test', author_id=1, creation_time=datetime.now(),
         active=True, version=None, description='Test type',
@@ -48,6 +50,7 @@ def example_type():
 
 @fixture(scope='module')
 def example_object():
+    "TODO: document"
     return CmdbObject(
         public_id=1, type_id=1, status=True, creation_time=datetime.now(timezone.utc),
         author_id=1, active=True, fields=[], version='1.0.0'
@@ -56,6 +59,7 @@ def example_object():
 
 @fixture(scope='module')
 def collection(connector, database_name):
+    """TODO: document"""
     from pymongo.mongo_client import MongoClient
     from pymongo.collection import Collection
     mongo_client: MongoClient = connector.client
@@ -65,6 +69,7 @@ def collection(connector, database_name):
 
 @fixture(scope='module', autouse=True)
 def setup(request, collection, example_type):
+    """TODO: document"""
     collection.insert_one(document=TypeModel.to_json(example_type))
     dummy_type = example_type
     dummy_type.public_id = 2
@@ -93,12 +98,13 @@ def setup(request, collection, example_type):
 
 
 class TestFrameworkObjects:
-
+    """TODO: document"""
     OBJECT_COLLECTION: str = CmdbObject.COLLECTION
     TYPE_COLLECTION: str = TypeModel.COLLECTION
     ROUTE_URL: str = '/objects'
 
     def test_insert_object(self, rest_api, example_object, full_access_user, none_access_user):
+        """TODO: document"""
         # Test default
         default_response = rest_api.post(f'{self.ROUTE_URL}/', json=CmdbObject.to_json(example_object))
         assert default_response.status_code == HTTPStatus.OK
@@ -150,7 +156,9 @@ class TestFrameworkObjects:
         assert validate_response.status_code == HTTPStatus.NOT_FOUND
         example_object.public_id = 1
 
+
     def test_get_objects(self, rest_api, full_access_user, none_access_user):
+        """TODO: document"""
         default_response = rest_api.get(f'{self.ROUTE_URL}/')
         assert default_response.status_code == HTTPStatus.OK
 
@@ -189,7 +197,9 @@ class TestFrameworkObjects:
         none_get_types_response = rest_api.get(f'{self.ROUTE_URL}/', unauthorized=True)
         assert none_get_types_response.status_code == HTTPStatus.UNAUTHORIZED
 
+
     def test_get_object(self, rest_api, example_object, full_access_user, none_access_user):
+        """TODO: document"""
         default_response = rest_api.get(f'{self.ROUTE_URL}/{example_object.public_id}/{"native"}')
         assert default_response.status_code == HTTPStatus.OK
 
@@ -214,7 +224,9 @@ class TestFrameworkObjects:
         none_get_types_response = rest_api.get(f'{self.ROUTE_URL}/{example_object.public_id}', unauthorized=True)
         assert none_get_types_response.status_code == HTTPStatus.UNAUTHORIZED
 
+
     def test_update_object(self, rest_api, example_object, full_access_user, none_access_user):
+        """TODO: document"""
         example_object.editor_id = 1
         example_object.creation_time = None
 
@@ -251,7 +263,9 @@ class TestFrameworkObjects:
         example_object.public_id = 1
         example_object.name = 'test'
 
+
     def test_delete_object(self, rest_api, example_object, full_access_user, none_access_user):
+        """TODO: document"""
         # Test default route
         rest_api.post(f'{self.ROUTE_URL}/', json=CmdbObject.to_json(example_object))
 

--- a/tests/functional/framework/test_functional_types.py
+++ b/tests/functional/framework/test_functional_types.py
@@ -13,15 +13,16 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
-
+"""TODO: document"""
 from json import dumps
-
-from pytest import fixture, importorskip
 from datetime import datetime
 from http import HTTPStatus
 
+from pytest import fixture, importorskip
+
 from cmdb.framework import TypeModel
-from cmdb.framework.models.type import TypeRenderMeta, TypeFieldSection, TypeSummary
+from cmdb.framework.models.type_model import TypeSummary
+from cmdb.framework.models.type_model import TypeFieldSection, TypeRenderMeta
 from cmdb.security.acl.control import AccessControlList
 from cmdb.security.acl.sections import GroupACL
 from tests.utils.flask_test_client import RestAPITestSuite
@@ -29,6 +30,7 @@ from tests.utils.flask_test_client import RestAPITestSuite
 
 @fixture(scope='module')
 def example_type():
+    """TODO: document"""
     return TypeModel(
         public_id=1, name='test', label='Test', author_id=1, creation_time=datetime.now(),
         active=True, version=None, description='Test type',
@@ -55,6 +57,7 @@ def example_type():
 
 @fixture(scope='module')
 def collection(connector, database_name):
+    """TODO: document"""
     from pymongo.mongo_client import MongoClient
     from pymongo.collection import Collection
     mongo_client: MongoClient = connector.client
@@ -64,6 +67,7 @@ def collection(connector, database_name):
 
 @fixture(scope='module', autouse=True)
 def setup(request, collection, example_type):
+    """TODO: document"""
     collection.insert_one(document=TypeModel.to_json(example_type))
 
     def drop_collection():
@@ -73,12 +77,14 @@ def setup(request, collection, example_type):
 
 
 class TestFrameworkTypes(RestAPITestSuite):
+    """TODO: document"""
     importorskip('cmdb.framework')
 
     COLLECTION: str = TypeModel.COLLECTION
     ROUTE_URL: str = '/types'
 
     def test_get_types(self, rest_api, full_access_user, none_access_user):
+        """TODO: document"""
         # Route callable
         default_response = rest_api.get(f'{self.ROUTE_URL}/')
         assert default_response.status_code == HTTPStatus.OK
@@ -119,7 +125,9 @@ class TestFrameworkTypes(RestAPITestSuite):
         none_get_types_response = rest_api.get(f'{self.ROUTE_URL}/', unauthorized=True)
         assert none_get_types_response.status_code == HTTPStatus.UNAUTHORIZED
 
+
     def test_get_type(self, rest_api, example_type, full_access_user, none_access_user):
+        """TODO: document"""
         # Route callable
         default_response = rest_api.get(f'{self.ROUTE_URL}/{example_type.public_id}')
         assert default_response.status_code == HTTPStatus.OK
@@ -147,7 +155,9 @@ class TestFrameworkTypes(RestAPITestSuite):
         none_get_types_response = rest_api.get(f'{self.ROUTE_URL}/{example_type.public_id}', unauthorized=True)
         assert none_get_types_response.status_code == HTTPStatus.UNAUTHORIZED
 
+
     def test_insert_type(self, rest_api, example_type, full_access_user, none_access_user):
+        """TODO: document"""
         example_type.public_id = 2
         example_type.name = 'test2'
 
@@ -185,7 +195,9 @@ class TestFrameworkTypes(RestAPITestSuite):
         example_type.public_id = 1
         example_type.name = 'test'
 
+
     def test_update_type(self, rest_api, example_type, full_access_user, none_access_user):
+        """TODO: document"""
         example_type.name = 'updated'
 
         # Test default route
@@ -218,6 +230,7 @@ class TestFrameworkTypes(RestAPITestSuite):
         example_type.name = 'test'
 
     def test_delete_type(self, rest_api, example_type, full_access_user, none_access_user):
+        """TODO: document"""
         # Test default route
         rest_api.post(f'{self.ROUTE_URL}/', json=TypeModel.to_json(example_type))
 
@@ -242,4 +255,3 @@ class TestFrameworkTypes(RestAPITestSuite):
         # ACCESS UNAUTHORIZED
         un_get_types_response = rest_api.delete(f'{self.ROUTE_URL}/{example_type.public_id}', unauthorized=True)
         assert un_get_types_response.status_code == HTTPStatus.UNAUTHORIZED
-

--- a/tests/unit/framework/test_unit_bulk_change_objects.py
+++ b/tests/unit/framework/test_unit_bulk_change_objects.py
@@ -13,22 +13,23 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-
+"""TODO: document"""
 import copy
-
-from pytest import fixture
 from datetime import datetime, timezone
 from http import HTTPStatus
 
+from pytest import fixture
+
 from cmdb.framework import TypeModel, CmdbObject
-from cmdb.framework.models.type import TypeRenderMeta, TypeFieldSection, TypeSummary
+from cmdb.framework.models.type_model import TypeSummary
+from cmdb.framework.models.type_model import TypeFieldSection, TypeRenderMeta
 from cmdb.security.acl.control import AccessControlList
 from cmdb.security.acl.sections import GroupACL
-
+# -------------------------------------------------------------------------------------------------------------------- #
 
 @fixture(scope='module')
 def example_type():
+    """TODO: document"""
     return TypeModel(
         public_id=1, name='test', label='Test', author_id=1, creation_time=datetime.now(),
         active=True, version=None, description='Test type',
@@ -54,6 +55,7 @@ def example_type():
 
 @fixture(scope='module')
 def example_object():
+    """TODO: document"""
     return CmdbObject(
         public_id=1, type_id=1, status=True, creation_time=datetime.now(timezone.utc),
         author_id=1, active=True, fields=[{
@@ -88,6 +90,7 @@ def change_object() -> dict:
 
 @fixture(scope='module')
 def collection(connector, database_name):
+    """TODO: document"""
     from pymongo.mongo_client import MongoClient
     from pymongo.collection import Collection
     client: MongoClient = connector.client
@@ -97,6 +100,7 @@ def collection(connector, database_name):
 
 @fixture(scope='module', autouse=True)
 def setup(request, collection, example_type):
+    """TODO: document"""
     collection.insert_one(document=TypeModel.to_json(example_type))
 
     def drop_collection():
@@ -105,7 +109,7 @@ def setup(request, collection, example_type):
     request.addfinalizer(drop_collection)
 
 class TestBulkChangeFrameworkObjects:
-
+    """TODO: document"""
     OBJECT_COLLECTION: str = CmdbObject.COLLECTION
     ROUTE_URL: str = '/objects'
 
@@ -126,7 +130,7 @@ class TestBulkChangeFrameworkObjects:
         assert len(rest_api.get(f'{self.ROUTE_URL}/').get_json()['results']) == 3
 
     def test_bulk_change_object_field_value(self, rest_api, change_object, full_access_user):
-
+        """TODO: document"""
         expectations = rest_api.get(f'{self.ROUTE_URL}/').get_json()['results']
         params = {'objectIDs': [1, 2, 3]}
 
@@ -152,7 +156,7 @@ class TestBulkChangeFrameworkObjects:
         assert results[2]['active'] == expectations[2]['active']
 
     def test_bulk_change_object_active_state(self, rest_api, change_object, full_access_user):
-
+        """TODO: document"""
         expectations = rest_api.get(f'{self.ROUTE_URL}/').get_json()['results']
         params = {'objectIDs': [1, 2, 3]}
 
@@ -167,6 +171,3 @@ class TestBulkChangeFrameworkObjects:
         assert results[0]['active']
         assert results[1]['active']
         assert results[2]['active']
-
-
-


### PR DESCRIPTION
Changes:
* Deleting global section templates will remove them from types, objects and summaries
* TypeModel has a new attribute: global_template_ids
* Popup for deleting global section templates