### PR TITLE
DAT-671-editing-fields-for-global-sections

### DIFF
--- a/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.html
+++ b/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.html
@@ -6,6 +6,11 @@
 <div class="modal-body">
     <div id="delete-message">
         Do you want to <b>delete</b> the section template <b>"{{sectionTemplate.label}}"</b>?
+        <br>
+        <br>
+        <ng-container *ngIf="sectionTemplate.is_global">
+            This action affects <b>{{templateCounts.types}} types</b> and <b>{{templateCounts.objects}} objects</b>!
+        </ng-container>
     </div>
     <ng-container *ngIf="sectionTemplate.is_global">
         <br>

--- a/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.ts
+++ b/app/src/app/framework/section_templates/layout/modals/section-template-delete/section-template-delete-modal.component.ts
@@ -18,6 +18,7 @@
 import { Component, Input } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { CmdbSectionTemplate } from 'src/app/framework/models/cmdb-section-template';
+import { GlobalTemplateCounts } from '../../../section-template.component';
 /* ------------------------------------------------------------------------------------------------------------------ */
 
 @Component({
@@ -29,6 +30,9 @@ export class SectionTemplateDeleteModalComponent {
 
   @Input() 
   public sectionTemplate: CmdbSectionTemplate;
+
+  @Input()
+  public templateCounts: GlobalTemplateCounts;
 
   constructor(public activeModal: NgbActiveModal) {
   }

--- a/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.html
+++ b/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.html
@@ -83,7 +83,7 @@
                     <div class="card-body">
                         <cmdb-section-field-edit
                             [data]="initialSection"
-                            [mode]="sectionTemplateID > 0 ? MODES.Global : MODES.Edit"
+                            [mode]="MODES.Edit"
                             #sectionComponent
                         ></cmdb-section-field-edit>
                         <form [formGroup]="formGroup">

--- a/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.ts
+++ b/app/src/app/framework/section_templates/layout/section-template-builder/section-template-builder.component.ts
@@ -56,7 +56,7 @@ export class SectionTemplateBuilderComponent implements OnInit {
     public sectionComponent: SectionFieldEditComponent;
 
     public initialSection: any = {
-        'name': this.randomName(),
+        'name': this.randomSectionName(),
         'label': 'Section',
         'type': 'section',
         'fields': []
@@ -110,7 +110,7 @@ export class SectionTemplateBuilderComponent implements OnInit {
 
         this.formGroup.controls['isGlobal'].valueChanges.subscribe(isGlobal => {
             if(isGlobal){
-                if(this.initialSection.name.includes('dg_gst')){
+                if(this.initialSection.name.includes('dg_gst-')){
                     this.sectionComponent.form.controls['name'].setValue(this.initialSection.name);
                 } else {
                     this.sectionComponent.form.controls['name'].setValue(this.generateGlobalSectionTemplateName());
@@ -120,7 +120,7 @@ export class SectionTemplateBuilderComponent implements OnInit {
                 if(this.initialSection.name.includes('section_template')){
                     this.sectionComponent.form.controls['name'].setValue(this.initialSection.name);
                 } else {
-                    this.sectionComponent.form.controls['name'].setValue(this.randomName());
+                    this.sectionComponent.form.controls['name'].setValue(this.randomSectionName());
                 }
             }
         });
@@ -288,8 +288,9 @@ export class SectionTemplateBuilderComponent implements OnInit {
      * 
      * @returns (string): random name for section
      */
-    public randomName() {
-        return `section_template-${Math.floor(Math.random() * (99999 - 10000 + 1)) + 10000}`;
+    public randomSectionName() {
+        const timestamp = new Date().getTime();
+        return `section_template-${timestamp}`;
     }
 
 

--- a/app/src/app/framework/section_templates/section-template.component.html
+++ b/app/src/app/framework/section_templates/section-template.component.html
@@ -8,7 +8,6 @@
                 <tr class="table-head">
                     <th>PublicID</th>
                     <th>Name</th>
-                    <th>Is Global</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -17,7 +16,6 @@
                     <tr *ngFor="let sectionTemplate of sectionTemplates">
                         <td class="centered-text small-cell">{{sectionTemplate.public_id}}</td>
                         <td class="centered-text">{{sectionTemplate.label}}</td>
-                        <td class="centered-text medium-cell">{{sectionTemplate.is_global}}</td>
                         <td class="centered-text big-cell">
                             <button class="btn btn-sm btn-link"
                                     title="Edit"
@@ -30,6 +28,14 @@
                                 (click)="showCloneModal(sectionTemplate)"
                             >
                                 <i class="far fa-clone"></i>
+                            </button>
+                            <button
+                                *ngIf="sectionTemplate.is_global"
+                                title="Global Template"
+                                class="btn btn-sm btn-link"
+                                disabled
+                            >
+                                <i class="fas fa-globe"></i>
                             </button>
                             <button
                                 *ngIf="!sectionTemplate.is_global"
@@ -51,7 +57,7 @@
                 </ng-container>
                 <ng-template #noSectionTemplatesMessage>
                     <tr>
-                        <td class="centered-text" colspan="4">No section templates created</td>
+                        <td class="centered-text" colspan="3">No section templates created</td>
                     </tr>
                 </ng-template>
             </tbody>

--- a/app/src/app/framework/section_templates/section-template.component.ts
+++ b/app/src/app/framework/section_templates/section-template.component.ts
@@ -29,6 +29,11 @@ import { SectionTemplateTransformModalComponent } from './layout/modals/section-
 import { SectionTemplateCloneModalComponent } from './layout/modals/section-template-clone/section-template-clone-modal.component';
 /* ------------------------------------------------------------------------------------------------------------------ */
 
+export interface GlobalTemplateCounts {
+    'types': number,
+    'objects': number
+}
+
 @Component({
     selector:'cmdb-section-template',
     templateUrl: './section-template.component.html',
@@ -79,19 +84,25 @@ export class SectionTemplateComponent implements OnInit, OnDestroy {
      * @param sectionTemplate instance of section template which should be deleted
      */
     showDeleteModal(sectionTemplate: CmdbSectionTemplate){
-        this.modalRef = this.modalService.open(SectionTemplateDeleteModalComponent, { size: 'lg' });
-        this.modalRef.componentInstance.sectionTemplate = sectionTemplate;
 
-        this.modalRef.result.then((sectionTemplateID: number) => {
-            //Delete the section template
-            if(sectionTemplateID > 0){
-                this.sectionTemplateService.deleteSectionTemplate(sectionTemplateID).subscribe((res: any) => {
-                    this.toastService.success("Section Template with ID " + sectionTemplateID  + " deleted!");
-                    this.getAllSectionTemplates();
-                }, error => {
-                  this.toastService.error(error);
-                });
-            }
+        this.sectionTemplateService.getGlobalSectionTemplateCount(sectionTemplate.public_id).subscribe((response: GlobalTemplateCounts) => {
+            let counts: GlobalTemplateCounts = response
+
+            this.modalRef = this.modalService.open(SectionTemplateDeleteModalComponent, { size: 'lg' });
+            this.modalRef.componentInstance.sectionTemplate = sectionTemplate;
+            this.modalRef.componentInstance.templateCounts = counts;
+    
+            this.modalRef.result.then((sectionTemplateID: number) => {
+                //Delete the section template
+                if(sectionTemplateID > 0){
+                    this.sectionTemplateService.deleteSectionTemplate(sectionTemplateID).subscribe((res: any) => {
+                        this.toastService.success("Section Template with ID " + sectionTemplateID  + " deleted!");
+                        this.getAllSectionTemplates();
+                    }, error => {
+                      this.toastService.error(error);
+                    });
+                }
+            });
         });
     }
 

--- a/app/src/app/framework/section_templates/services/section-template.service.ts
+++ b/app/src/app/framework/section_templates/services/section-template.service.ts
@@ -136,6 +136,18 @@ export class SectionTemplateService<T = CmdbSectionTemplate | RenderResult> impl
         );
     }
 
+
+    public getGlobalSectionTemplateCount<R>(publicID: number): Observable<R>{
+        const options = this.options;
+        options.params = new HttpParams();
+
+        return this.api.callGet<R[]>(`${ this.servicePrefix }/${ publicID }/count`, options).pipe(
+            map((apiResponse) => {
+                return apiResponse.body;
+            })
+        );
+    }
+
 /* -------------------------------------------------- CRUD - UPDATE ------------------------------------------------- */
 
     /**
@@ -158,11 +170,8 @@ export class SectionTemplateService<T = CmdbSectionTemplate | RenderResult> impl
 
         putOptions.params = httpParams;
 
-        console.log("send params:", putOptions.params);
-
         return this.api.callPut<T>(`${ this.servicePrefix }/`, params, putOptions).pipe(
             map((apiResponse: HttpResponse<APIUpdateSingleResponse<T>>) => {
-                console.log("updateResponse:", apiResponse.body);
                 return apiResponse.body;
             })
         );

--- a/app/src/app/framework/type/builder/builder.component.ts
+++ b/app/src/app/framework/type/builder/builder.component.ts
@@ -180,6 +180,7 @@ export class BuilderComponent implements OnChanges, OnDestroy {
      */
     public onSectionDrop(event: DndDropEvent): void {
         let sectionData = event.data;
+
         //check if it is a section template
         if('is_global' in sectionData){
 
@@ -367,10 +368,11 @@ export class BuilderComponent implements OnChanges, OnDestroy {
 
 
     public getSectionMode(section: CmdbTypeSection, mode: CmdbMode){
-        if(this.isGlobalSection(section)){
+
+        if(this.isGlobalSection(section) || section.name.includes("dg_gst-")){
             return CmdbMode.Global
         }
-
+        
         if(this.isNewSection(section)){
             return CmdbMode.Create
         }

--- a/app/src/app/framework/type/builder/configs/config.edit.ts
+++ b/app/src/app/framework/type/builder/configs/config.edit.ts
@@ -90,6 +90,7 @@ export abstract class ConfigEditBaseComponent {
     }
   }
 
+
   protected patchData(data: any, form: UntypedFormGroup): void {
     form.patchValue(data);
     if (this.mode === CmdbMode.Edit) {
@@ -97,29 +98,29 @@ export abstract class ConfigEditBaseComponent {
     }
   }
 
-  public calculateName(value) {
-    if (this.mode !== CmdbMode.Edit) {
-      this.data.name = value.replace(/ /g, '-').toLowerCase();
-      this.data.name = this.data.name.replace(/[^a-z0-9 \-]/gi, '').toLowerCase();
-    }
-    if (!this.checkNameUniqueness()) {
-      this.calculateName(this.data.name += '-1');
-    }
-  }
+  // public calculateName(value) {
+  //   if (this.mode !== CmdbMode.Edit) {
+  //     this.data.name = value.replace(/ /g, '-').toLowerCase();
+  //     this.data.name = this.data.name.replace(/[^a-z0-9 \-]/gi, '').toLowerCase();
+  //   }
+  //   if (!this.checkNameUniqueness()) {
+  //     this.calculateName(this.data.name += '-1');
+  //   }
+  // }
 
-  private checkNameUniqueness() {
-    const { type, name } = this.data;
-    switch (type) {
-      case 'section':
-        return this.sections.filter(el => el.name === name).length <= 1;
-      default:
-        let count = 0;
-        this.sections.forEach((sec) => {
-          count += sec.fields.filter(el => el.name === name).length;
-        });
-        return count <= 1;
-    }
-  }
+  // private checkNameUniqueness() {
+  //   const { type, name } = this.data;
+  //   switch (type) {
+  //     case 'section':
+  //       return this.sections.filter(el => el.name === name).length <= 1;
+  //     default:
+  //       let count = 0;
+  //       this.sections.forEach((sec) => {
+  //         count += sec.fields.filter(el => el.name === name).length;
+  //       });
+  //       return count <= 1;
+  //   }
+  // }
 
   private updateAndClearValidators(control: UntypedFormControl) {
     control.clearValidators();

--- a/app/src/app/framework/type/builder/configs/section/section-field-edit.component.html
+++ b/app/src/app/framework/type/builder/configs/section/section-field-edit.component.html
@@ -1,15 +1,15 @@
 <div [formGroup]="form">
   <div class="form-row">
     <div class="form-group col-md-12">
-      <label>Name: <span class="required">*</span></label>
+      <label>Identifier: <span class="required">*</span></label>
       <input [formControl]="nameControl" type="text" class="form-control" name-guideline
              (ngModelChange)="onInputChange($event, 'name')"
              [ngClass]="{ 'is-valid': nameControl.valid && (nameControl.dirty || nameControl.touched),
                  'is-invalid': nameControl.invalid && (nameControl.dirty || nameControl.touched)}">
-      <small class="form-text text-muted float-left">Use a unique field-name</small>
+      <small class="form-text text-muted float-left">Use a unique identifier</small>
       <div *ngIf="nameControl.invalid && (nameControl.dirty || nameControl.touched)" class="invalid-feedback">
         <div class="float-right" *ngIf="nameControl.errors?.required">
-          Name is a required field.
+          Identifier is a required field.
         </div>
       </div>
       <div class="clearfix"></div>

--- a/cmdb/framework/cmdb_section_template_manager.py
+++ b/cmdb/framework/cmdb_section_template_manager.py
@@ -20,6 +20,7 @@ The implementation of the manager used is always realized using the respective s
 """
 import logging
 from queue import Queue
+from deepdiff import DeepDiff
 
 from cmdb.framework.managers.type_manager import TypeManager
 from cmdb.framework.cmdb_object_manager import CmdbObjectManager
@@ -126,12 +127,165 @@ class CmdbSectionTemplateManager(CmdbManagerBase):
 
 # ------------------------------------------------- HELPER FUNCTIONS ------------------------------------------------- #
 
-    def cleanup_global_section_templates(self, template_name: str) -> None:
+    def handle_section_template_changes(self, new_params: dict, current_template: CmdbSectionTemplate) -> None:
         """
-        Removes the global section template from types, summaries and objects
+        Handles changes to global section templates and updates all used instances
+        
+        Args:
+            params (dict): The new values for the section template
+        """
+        updated_field_names: list[str] = []
+
+        for new_field in new_params['fields']:
+            updated_field_names.append(new_field['name'])
+
+        new_section_label: str = self.get_section_label_diff(new_params, CmdbSectionTemplate.to_json(current_template))
+        field_diffs = self.get_fields_diff(new_params, CmdbSectionTemplate.to_json(current_template))
+        LOGGER.info(f"field_diffs: {field_diffs}")
+
+        types_to_change = self.get_types_using_template(new_params['name'])
+
+        a_type: TypeModel
+        for a_type in types_to_change:
+
+            to_change_global_section: TypeFieldSection = a_type.get_section(new_params['name'])
+            LOGGER.info(f"to_change_global_section: {to_change_global_section}")
+
+            # Change label if it was changed
+            if len(new_section_label) > 0:
+                to_change_global_section.label = new_section_label
+
+            # Remove deleted fields from type summary
+            a_type.render_meta.summary.fields = [field_name for field_name in a_type.render_meta.summary.fields
+                                                  if field_name not in field_diffs['deleted']]
+
+            # Replace the old section fields with new section fields
+            to_change_global_section.fields = []
+
+            for a_field in new_params['fields']:
+                to_change_global_section.fields.append(a_field['name'])
+
+            # Update the section on the type
+            for i, a_section in enumerate(a_type.render_meta.sections):
+
+                if a_section.name == to_change_global_section.name:
+                    a_type.render_meta.sections[i] = to_change_global_section
+                    break
+
+            # Remove deleted fields from type fields since they are not in the new fields
+            a_type.fields = [field for field in a_type.fields if field['name'] not in field_diffs['deleted']]
+            # Remove also the other section fields and add all as new fields
+            a_type.fields = [field for field in a_type.fields if field['name'] not in updated_field_names]
+
+            for new_field in new_params['fields']:
+                a_type.fields.append(new_field)
+
+            # Delete all deleted fields from objects
+            self.cleanup_global_section_objects(a_type.public_id, field_diffs['deleted'])
+
+            # Add all new created fields to objects
+            new_field_names: list[str] = []
+
+            for new_field in field_diffs['added']:
+                new_field_names.append(new_field['name'])
+
+            self.set_new_global_template_fields(a_type.public_id, new_field_names)
+
+            #Update the type changes for the type
+            self.type_manager.update(a_type.public_id, a_type)
+
+
+    def get_section_label_diff(self, new_params: dict, current_params: dict) -> str:
+        """
+        Checks if the label of the global section template got changed
+        
+        Args:
+            new_params (dict): Changes to current global section template
+            current_params (dict): Current version of the global section template
+
+        Returns:
+            str: The new label if it is changed else empty string
+        """
+        diff: str = ""
+        if new_params['label'] != current_params['label']:
+            diff = new_params['label']
+
+        return diff
+
+
+    def get_fields_diff(self, new_params: dict, current_params: dict) -> dict:
+        """
+        Checks all fields of the template for differences
 
         Args:
-            template_name (str): The name of the global section template
+            new_params (dict): The new version of the template
+            current_params (dict): The current version of the template
+
+        Returns:
+            dict: All added, deleted and changed fields
+        """
+        deleted_fields: list[str] = []
+        added_fields: list = []
+        changed_fields: list = []
+
+        processed_field_names: list[str] = []
+        # Check for deleted fields
+        for old_field in current_params['fields']:
+            found: bool = False
+
+            for new_field in new_params['fields']:
+
+                if old_field['name'] == new_field['name']:
+                    found = True
+                    break
+
+            # The old field is not found in new params, so it has to be deleted
+            if not found:
+                processed_field_names.append(old_field['name'])
+                deleted_fields.append(old_field['name'])
+
+
+        # Check for added fields
+        for new_field in new_params['fields']:
+            found: bool = False
+
+            for old_field in current_params['fields']:
+
+                if old_field['name'] == new_field['name']:
+                    found = True
+                    break
+
+            if not found:
+                processed_field_names.append(new_field['name'])
+                added_fields.append(new_field)
+
+        # Check remaining fields if there are any changes
+        remaining_fields: list = [field for field in new_params['fields'] if field['name'] not in processed_field_names]
+
+        for remaining_field in remaining_fields:
+            for old_field in current_params['fields']:
+                # Find the changes
+                if remaining_field['name'] == old_field['name']:
+                    difference = DeepDiff(old_field, remaining_field)
+                    if len(difference) > 0:
+                        changed_fields.append(remaining_field)
+
+        return {
+            'added': added_fields,
+            'deleted': deleted_fields,
+            'changed': changed_fields
+        }
+
+
+    def get_types_using_template(self, template_name: str) -> list:
+        """
+        Retrives types which are using the current global template
+
+        Args:
+            template_name (str): Name of the global template
+
+        Returns:
+            ListResult: All types using the given global template
         """
         type_filter: dict = {
             "global_template_ids":template_name
@@ -139,8 +293,20 @@ class CmdbSectionTemplateManager(CmdbManagerBase):
 
         found_types: ListResult = self.type_manager.find(type_filter)
 
+        return found_types.results
+
+
+    def cleanup_global_section_templates(self, template_name: str) -> None:
+        """
+        Removes the global section template from types, summaries and objects
+
+        Args:
+            template_name (str): The name of the global section template
+        """
+        found_types: ListResult = self.get_types_using_template(template_name)
+
         a_type: TypeModel
-        for a_type in found_types.results:
+        for a_type in found_types:
             #remove the template_name from the type
             a_type.global_template_ids.remove(template_name)
 
@@ -182,6 +348,70 @@ class CmdbSectionTemplateManager(CmdbManagerBase):
             an_object.fields = [field for field in an_object.fields if field['name'] not in section_field_names]
 
             self.object_manager.update(an_object.public_id, an_object)
+
+
+    def set_new_global_template_fields(self, type_id: int, new_field_names: list[str]) -> None:
+        """
+        Sets all new fields on every object
+
+        Args:
+            type_id (int): ID of the TypeModel
+            new_field_names (list[str]): List of names of new fields
+        """
+        section_objects: list = self.cmdb_object_manager.get_objects_by_type(type_id)
+
+        an_object: CmdbObject
+        for an_object in section_objects:
+
+            for a_field_name in new_field_names:
+                an_object.fields.append({
+                    'name': a_field_name,
+                    'value': None
+                })
+
+            self.object_manager.update(an_object.public_id, an_object)
+
+
+    def get_global_template_usage_count(self, template_name: str, is_global: bool) -> dict:
+        """
+        Retrieves the number of types and objects using this template if it is global
+
+        Args:
+            template_name (str): Name of template
+            is_global (bool): If this template is global
+
+        Returns:
+            dict: Counts of types and objects which use this template
+        """
+        counts = {
+            'types': 0,
+            'objects': 0
+        }
+
+        if not is_global:
+            return counts
+
+        type_filter: dict = {
+            "global_template_ids":template_name
+        }
+
+        found_types: ListResult = self.type_manager.find(type_filter)
+
+        if len(found_types.results) == 0:
+            return counts
+
+        counts['types'] = len(found_types.results)
+
+        objects_count: int = 0
+
+        a_type: TypeModel
+        for a_type in found_types.results:
+            objects: list = self.cmdb_object_manager.get_objects_by_type(a_type.public_id)
+            objects_count += len(objects)
+
+        counts['objects'] = objects_count
+
+        return counts
 
 
     def get_new_id(self, collection: str) -> int:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ chardet==5.2.0
 click==8.1.7
 coverage==7.3.2
 cryptography==41.0.5
+deepdiff==6.7.1
 docutils==0.20.1
 et-xmlfile==1.1.0
 flake8==6.1.0


### PR DESCRIPTION
Changes:
* Renamed "Name" to "Identifier" for sections
* Section Template Names can be edited
* Changes to global section templates are applied to types and objects (Add field, delete field, edit field)
* Delete popup for a global section template now cotains the number of affected types and objects
* Fixed some minor issues