### PR TITLE
Save button useable in object link creation

### DIFF
--- a/app/src/app/framework/object/modals/object-link-add-modal/object-link-add-modal.component.html
+++ b/app/src/app/framework/object/modals/object-link-add-modal/object-link-add-modal.component.html
@@ -32,7 +32,7 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-outline-dark" (click)="activeModal.dismiss('Close click')">Close</button>
-    <button type="button" class="btn btn-outline-primary" (click)="onSave()">Save</button>
+    <button type="button" class="btn btn-outline-dark" (click)="activeModal.dismiss('Close click')" >Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="onSave()" [disabled]="secondary.invalid && (secondary.dirty || secondary.touched) || !secondary.value ">Save</button>
   </div>
 </form>


### PR DESCRIPTION
Fixed: Deactivate save button in object link creation when input is empty or invalid