### PR TITLE
DAT-732-remove-python-packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,12 @@
 alabaster==0.7.13
 altgraph==0.17.4
 astroid==3.0.1
-attrs==23.1.0
 Authlib==1.2.1
 Babel==2.13.1
 blinker==1.7.0
 Cerberus==1.3.5
 certifi==2023.7.22
 cffi==1.16.0
-chardet==5.2.0
 click==8.1.7
 coverage==7.3.2
 cryptography==41.0.5
@@ -25,7 +23,6 @@ imagesize==1.4.1
 iniconfig==2.0.0
 isort==5.12.0
 itsdangerous==2.1.2
-jdcal==1.4.1
 Jinja2==3.1.2
 lazy-object-proxy==1.9.0
 ldap3==2.9.1
@@ -36,7 +33,6 @@ packaging==23.2
 pika==0.12.0
 Pillow==10.1.0
 pluggy==1.3.0
-py==1.11.0
 pyasn1==0.5.0
 pycairo==1.25.1
 pycodestyle==2.11.1
@@ -50,14 +46,11 @@ pylint==3.0.2
 pymongo==4.6.0
 PyMySQL==1.1.0
 pyOpenSSL==23.3.0
-pyparsing==3.1.1
-PyPDF2==3.0.1
 pytest==7.4.3
 pytest-cov==4.1.0
 pytest-html==4.1.1
 pytest-metadata==3.0.0
 python-dateutil==2.8.2
-pytz==2023.3.post1
 reportlab==4.0.7
 requests==2.31.0
 six==1.16.0
@@ -70,9 +63,7 @@ sphinxcontrib-httpdomain==1.8.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.6
 sphinxcontrib-serializinghtml==1.1.9
-toml==0.10.2
 urllib3==2.0.7
 webencodings==0.5.1
 Werkzeug==3.0.1
-wrapt==1.15.0
 xhtml2pdf==0.2.13


### PR DESCRIPTION
Changes:
* Removed unused python packages from requirements.txt:
* attrs
* chardet
* py
* pyparsing
* PyPDF2
* pytz
* wrapt
* jdcal
* toml