### PR TITLE
DAT-771 bump cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.16
 altgraph==0.17.4
 astroid==3.1.0
-Authlib==1.2.1
+Authlib==1.3.0
 Babel==2.14.0
 blinker==1.7.0
 Cerberus==1.3.5
@@ -9,7 +9,7 @@ certifi==2024.2.2
 cffi==1.16.0
 click==8.1.7
 coverage==7.4.3
-cryptography==41.0.5
+cryptography==42.0.5
 deepdiff==6.7.1
 docutils==0.20.1
 et-xmlfile==1.1.0
@@ -45,7 +45,7 @@ pyinstaller-hooks-contrib==2024.3
 pylint==3.1.0
 pymongo==4.6.2
 PyMySQL==1.1.0
-pyOpenSSL==23.3.0
+pyOpenSSL==24.1.0
 pytest==8.1.1
 pytest-cov==4.1.0
 pytest-html==4.1.1


### PR DESCRIPTION
Bumped python packages
Changes:
* cryptography to 42.0.5
* pyOpenSSL to 24.1.0
* Authlib to 1.3.0