### PR TITLE
Fixed: Button Disabled When Changing Identifier Before Dropping Field

### DIFF
--- a/app/src/app/framework/type/builder/builder.component.ts
+++ b/app/src/app/framework/type/builder/builder.component.ts
@@ -371,6 +371,10 @@ export class BuilderComponent implements OnChanges, OnDestroy {
      * @param data new data for field
      */
     private handleFieldChanges(data: any) {
+
+        if (data.elementType == 'section') {
+            this.validationService.updateSectionKey(data.previousName, data.fieldName)
+        }
         if (data.inputName == "hideField") {
             this.handleHideFields(data);
             return;

--- a/app/src/app/framework/type/services/validation.service.ts
+++ b/app/src/app/framework/type/services/validation.service.ts
@@ -57,18 +57,24 @@ export class ValidationService {
         );
         this.isValid$.next(overallValidity);
     }
+
+
+    /**
+     * Updates a section's key in the sectionValidity map.
+     * 
+     * @param prevKey - The previous identifier of the section.
+     * @param newKey - The new identifier of the section.
+     * @returns Whether the update was successful.
+     */
+    updateSectionKey(prevKey: string, newKey: string) {
+        if (this.sectionValidity.has(prevKey)) {
+            const isValid = this.sectionValidity.get(prevKey);
+            this.sectionValidity.delete(prevKey);
+            this.sectionValidity.set(newKey, isValid!);
+            const overallValidity = Array.from(this.sectionValidity.values()).every(
+                (isValid) => isValid
+            );
+            this.sectionValidity$.next(overallValidity);
+        }
+    }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Fixed an issue where the button became disabled when changing the identifier before dropping a field. Now, the button functions correctly regardless of the order of these actions.