### PR TITLE
DAT-1661-duplicate-risk-assessments

### DIFF
--- a/cmdb/interface/rest_api/routes/framework_routes/objects_routes.py
+++ b/cmdb/interface/rest_api/routes/framework_routes/objects_routes.py
@@ -1470,7 +1470,7 @@ def delete_object_with_child_objects(public_id: int, request_user: CmdbUser):
 @insert_request_user
 @verify_api_access(required_api_level=ApiLevel.ADMIN)
 @objects_blueprint.protect(auth=True, right='base.framework.object.delete')
-def delete_many_cmdb_objects(public_ids, request_user: CmdbUser):
+def delete_many_cmdb_objects(public_ids: str, request_user: CmdbUser):
     """
     Deletes multiple CmdbObjects by their public_ids
 

--- a/cmdb/interface/rest_api/routes/isms_routes/isms_report_routes.py
+++ b/cmdb/interface/rest_api/routes/isms_routes/isms_report_routes.py
@@ -318,11 +318,15 @@ def get_isms_risk_treatment_plan_report(request_user: CmdbUser):
                     "object_id_ref_type": 1,
                     "risk_before": {
                         "value": "$risk_before.calculated_value",
+                        "risk_class_id": "$risk_before_class.public_id",
                         "color": "$risk_before_class.color"
                     },
                     "risk_after": {
                         "value": {
                             "$ifNull": ["$risk_after.calculated_value", None]
+                        },
+                        "risk_class_id": {
+                            "$ifNull": ["$risk_after_class.public_id", None]
                         },
                         "color": {
                             "$ifNull": ["$risk_after_class.color", None]
@@ -364,7 +368,7 @@ def get_isms_risk_treatment_plan_report(request_user: CmdbUser):
         for item in query_result:
             if item.get("object") and item.get("object_id_ref_type") == "OBJECT":
                 try:
-                    object_summary = objects_manager.get_summary_line(item["object"])
+                    object_summary = objects_manager.get_summary_line(item["object"], with_type=False)
                     item["object"] = object_summary
                 except Exception:
                     item["object"] = "Unknown object"
@@ -890,11 +894,15 @@ def get_isms_risk_assessments_report(request_user: CmdbUser):
                 },
                 "risk_before": {
                     "value": "$risk_before.calculated_value",
+                    "risk_class_id": "$risk_before_class.public_id",
                     "color": "$risk_before_class.color"
                 },
                 "risk_after": {
                     "value": {
                         "$ifNull": ["$risk_after.calculated_value", None]
+                    },
+                    "risk_class_id": {
+                        "$ifNull": ["$risk_after_class.public_id", None]
                     },
                     "color": {
                         "$ifNull": ["$risk_after_class.color", None]
@@ -930,7 +938,7 @@ def get_isms_risk_assessments_report(request_user: CmdbUser):
         for item in query_result:
             if item.get("object") and item.get("object_id_ref_type") == "OBJECT":
                 try:
-                    object_summary = objects_manager.get_summary_line(item["object"])
+                    object_summary = objects_manager.get_summary_line(item["object"], with_type=False)
                     item["object"] = object_summary
                 except Exception:
                     item["object"] = "Unknown object"

--- a/cmdb/manager/objects_manager.py
+++ b/cmdb/manager/objects_manager.py
@@ -915,33 +915,39 @@ class ObjectsManager(BaseManager):
             raise ObjectsManagerCheckError(err) from err
 
 
-    def get_summary_line(self, public_id: int) -> str:
+    def get_summary_line(self, public_id: int, with_type: bool = True) -> str:
         """
         Retrieves the summary line of an CmdbObject
 
         Args:
             public_id (int): public_id of the CmdbObject
+            with_type (bool): If True then the Type label should be part of the summary line
 
         Returns:
             str: The summary line of the CmdbObject
         """
         try:
+            default_line = ""
+
             if not public_id:
-                return ""
+                return default_line
 
             target_object = self.get_object(public_id)
 
             if not target_object:
-                return ""
+                return default_line
 
             object_type_id = target_object.get('type_id')
 
             target_object_type = self.get_object_type(object_type_id)
 
             if not target_object_type:
-                return ""
+                return default_line
 
-            default_line = f"{target_object_type.label} #{target_object.get('public_id')}"
+            if with_type:
+                default_line = f"{target_object_type.label} #{target_object.get('public_id')}"
+            else:
+                default_line = f"#{target_object.get('public_id')}"
 
             if not target_object_type.has_summaries():
                 return default_line


### PR DESCRIPTION
Changes:
* Added backend logics + route to duplicate a risk assessment
* removed type label from object summaries in ISMS reports
