### PR TITLE
DAT-1921 bump flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,12 +11,12 @@ certifi==2025.8.3
 cffi==1.17.1
 click==8.2.1
 coverage==7.10.2
-cryptography==42.0.8
+cryptography==45.0.5
 deepdiff==8.5.0
 docutils==0.21.2
 et-xmlfile==2.0.0
 flake8==7.3.0
-Flask==3.0.3
+Flask==3.1.1
 Flask-Cors==6.0.1
 google-generativeai==0.8.5
 gunicorn==23.0.0
@@ -45,7 +45,7 @@ pyinstaller==6.15.0
 pyinstaller-hooks-contrib==2025.8
 pylint==3.3.7
 pymongo==4.7.3
-pyOpenSSL==24.1.0
+pyOpenSSL==25.1.0
 pytest==8.4.1
 pytest-cov==6.2.1
 pytest-html==4.1.1
@@ -53,7 +53,7 @@ pytest-metadata==3.1.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 reportlab==4.4.3
-requests==2.32.3
+requests==2.32.4
 six==1.17.0
 snowballstemmer==2.2.0
 Sphinx==7.3.7
@@ -67,7 +67,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-redoc==1.6.0
 sphinxcontrib-serializinghtml==1.1.10
-urllib3==2.2.2
+urllib3==2.5.0
 webencodings==0.5.1
-Werkzeug==3.0.3
+Werkzeug==3.1.3
 xhtml2pdf==0.2.17


### PR DESCRIPTION
Changes:
* bumped flask to 3.1.1
* bumped werkzeug to 3.1.3
* bumped requests to 2.32.4
* bumped urllib3 to 2.5.0
* bumped pyOpenSSL to 25.1.0
* bumped cryptography to 45.0.5