### PR TITLE
chore(gitignore): add rules to ignore Samba .smbdelete* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ target/
 ._*
 .DS_Store
 node_modules/
+
+
+# Ignore Samba temporary delete marker files created in VM shared folders
+.smbdelete*
+**/.smbdelete*


### PR DESCRIPTION
Ignore Samba temporary delete marker files to keep repo clean.